### PR TITLE
Miscellaneous fixes

### DIFF
--- a/catala.scm
+++ b/catala.scm
@@ -446,7 +446,7 @@
 
 ;; Pattern-matching cases
 
-((ALT) (match_case ((COLON) @prepend_space @append_spaced_softline @append_indent_start) (_) @append_indent_end .)) @prepend_spaced_softline
+((ALT) . (match_case ((COLON) @prepend_space @append_spaced_softline @append_indent_start) (_) @append_indent_end .)) @prepend_spaced_softline
 
 ;; Let-bindings
 (e_letin

--- a/catala.scm
+++ b/catala.scm
@@ -422,6 +422,14 @@
  (#single_line_only!)
 )
 
+(typ
+ .
+ (LPAREN) @append_antispace
+ (RPAREN) @prepend_antispace
+ .
+ (#single_line_only!)
+)
+
 (e_tuple
  .
  (LPAREN) @append_spaced_softline @append_indent_start

--- a/catala.scm
+++ b/catala.scm
@@ -163,16 +163,26 @@
  (scope_var)
 ] @append_space
 
-;; Parenthesis and comma should not have any space
+;; No space before a COMMA -- except when preceded by a numeric literal
+;; FIXME: it only matters in catala_fr (e.g., 1+2,3 => would yield a parse error)
+(typ_list
+ (COMMA) @prepend_antispace)
+(var_list
+ (COMMA) @prepend_antispace)
 
-;; [                              ;;
-;;  (LPAREN (#single_line_only!)) ;;
-;; ] @append_antispace            ;;
-;; [                              ;;
-;;  (RPAREN (#single_line_only!)) ;;
-;; ] @prepend_antispace           ;;
+(tuple_contents
+ (_
+  (literal
+   [ (DECIMAL_LITERAL) (INT_LITERAL) ])? @do_nothing
+   .)
+ . (COMMA) @prepend_antispace)
 
-(COMMA) @prepend_antispace
+(fun_arguments
+ (COMMA) @prepend_antispace)
+(rule_parameters
+ (COMMA) @prepend_antispace)
+(params_decl
+ (COMMA) @prepend_antispace)
 
 ;; No space between integer and percent for decimals declarations
 

--- a/tests/en/tutorial_en.catala_en.result
+++ b/tests/en/tutorial_en.catala_en.result
@@ -1081,7 +1081,7 @@ commas, and delimited by parentheses as so:
 
 ```catala
 declaration scope UseOfTuple:
-  internal money_and_date content (money, date )
+  internal money_and_date content (money, date)
   output when content date
 
 scope UseOfTuple:

--- a/tests/fr/archives.catala_fr.result
+++ b/tests/fr/archives.catala_fr.result
@@ -69,37 +69,37 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     et selon personne_à_charge sous forme
     -- EnfantÀCharge de enfant : faux
     -- AutrePersonneÀCharge de parent :
-        parent.parenté = Ascendant
-        et parent.ressources
-        <= plafond_individuel_l815_9_sécu * 1,25
-        et (
-          # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
-          # à détecter
-          (
-            parent.date_naissance
-            + âge_l351_8_1_sécu
-            <= date_courante
-            ou (
-              parent.titulaire_allocation_personne_âgée
-              et (
-                résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
-                  -- date_naissance: parent.date_naissance
-                  -- date_courante: date_courante
-                  -- années: 65 an
-                }
-              ).est_inférieur_ou_égal
-            )
-          )
-          ou
-          # VERIF: parent.date_naissance + âge_l161_17_2_sécu est ambiguë,
-          # à détecter
-          (
-            parent.date_naissance
-            + âge_l161_17_2_sécu
-            <= date_courante
-            et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
+      parent.parenté = Ascendant
+      et parent.ressources
+      <= plafond_individuel_l815_9_sécu * 1,25
+      et (
+        # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
+        # à détecter
+        (
+          parent.date_naissance
+          + âge_l351_8_1_sécu
+          <= date_courante
+          ou (
+            parent.titulaire_allocation_personne_âgée
+            et (
+              résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
+                -- date_naissance: parent.date_naissance
+                -- date_courante: date_courante
+                -- années: 65 an
+              }
+            ).est_inférieur_ou_égal
           )
         )
+        ou
+        # VERIF: parent.date_naissance + âge_l161_17_2_sécu est ambiguë,
+        # à détecter
+        (
+          parent.date_naissance
+          + âge_l161_17_2_sécu
+          <= date_courante
+          et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
+        )
+      )
   conséquence rempli
 
   étiquette r823_4_2
@@ -133,14 +133,14 @@ champ d'application ÉligibilitéAidesPersonnelleLogement
     selon personne_à_charge sous forme
     -- EnfantÀCharge de enfant : faux
     -- AutrePersonneÀCharge de parent :
-        (
-          parent.parenté sous forme Ascendant
-          ou parent.parenté sous forme Descendant
-          ou parent.parenté sous forme CollatéralDeuxièmeTroisièmeDegré
-        )
-        et parent.incapacité_80_pourcent_ou_restriction_emploi
-        et parent.ressources
-        <= plafond_individuel_l815_9_sécu * 1,25
+      (
+        parent.parenté sous forme Ascendant
+        ou parent.parenté sous forme Descendant
+        ou parent.parenté sous forme CollatéralDeuxièmeTroisièmeDegré
+      )
+      et parent.incapacité_80_pourcent_ou_restriction_emploi
+      et parent.ressources
+      <= plafond_individuel_l815_9_sécu * 1,25
   conséquence rempli
 ```
 
@@ -485,9 +485,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       420,52€ + 61,01€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        370,32€ + 53,90€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      370,32€ + 53,90€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          342,52€ + 49,09€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      342,52€ + 49,09€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 ### Article 8 | LEGIARTI000046206214 [archive]
@@ -878,9 +878,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       315,39€ + 45,76€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        277,74€ + 40,43€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      277,74€ + 40,43€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          256,89€ + 36,82€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      256,89€ + 36,82€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 2° Le montant forfaitaire au titre des charges est fixé comme suit (en euros) :
@@ -1043,63 +1043,63 @@ champ d'application CalculAidePersonnaliséeLogementFoyer
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 422,42 €
-                -- Couple : 492,99€
-              )
-            sinon
-              (
-                si nombre_personnes_à_charge = 1 alors
-                  525,65 €
-                sinon
-                  (
-                    si nombre_personnes_à_charge = 2 alors
-                      562,68 €
-                    sinon
-                      (
-                        si nombre_personnes_à_charge = 3 alors
-                          599,57 €
-                        sinon
-                          (
-                            638,87 €
-                            + 66,59€ * (décimal de (nombre_personnes_à_charge - 4))
-                          )
-                      )
-                  )
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 400,96 €
-                  -- Couple : 466,34€
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 422,42 €
+              -- Couple : 492,99€
+            )
+          sinon
+            (
+              si nombre_personnes_à_charge = 1 alors
+                525,65 €
               sinon
                 (
-                  si nombre_personnes_à_charge = 1 alors
-                    494,75 €
+                  si nombre_personnes_à_charge = 2 alors
+                    562,68 €
                   sinon
                     (
-                      si nombre_personnes_à_charge = 2 alors
-                        527,40 €
+                      si nombre_personnes_à_charge = 3 alors
+                        599,57 €
                       sinon
                         (
-                          si nombre_personnes_à_charge = 3 alors
-                            560,04 €
-                          sinon
-                            (
-                              596,75 €
-                              + 61,80€ * (décimal de (nombre_personnes_à_charge - 4))
-                            )
+                          638,87 €
+                          + 66,59€ * (décimal de (nombre_personnes_à_charge - 4))
                         )
                     )
                 )
             )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 400,96 €
+              -- Couple : 466,34€
+            )
+          sinon
+            (
+              si nombre_personnes_à_charge = 1 alors
+                494,75 €
+              sinon
+                (
+                  si nombre_personnes_à_charge = 2 alors
+                    527,40 €
+                  sinon
+                    (
+                      si nombre_personnes_à_charge = 3 alors
+                        560,04 €
+                      sinon
+                        (
+                          596,75 €
+                          + 61,80€ * (décimal de (nombre_personnes_à_charge - 4))
+                        )
+                    )
+                )
+            )
+        )
     )
 ```
 
@@ -2335,9 +2335,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       406,30€ + 58,95€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        357,80€ + 52,08€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      357,80€ + 52,08€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          330,94€ + 47,43€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      330,94€ + 47,43€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 ### Article 8 | LEGIARTI000044137429 [archive]
@@ -2671,9 +2671,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       304,73€ + 44,21€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        268,35€ + 39,06€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      268,35€ + 39,06€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          248,21€ + 35,57€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      248,21€ + 35,57€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 2° Le montant forfaitaire au titre des charges est fixé comme suit (en euros) :
@@ -2819,39 +2819,39 @@ champ d'application CalculAidePersonnaliséeLogementFoyer
           686,37 € + 71,19€ * (décimal de (nombre_personnes_à_charge - 4))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 408,14 €
-              -- Couple : 476,32€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors
-            507,87 €
-          sinon si nombre_personnes_à_charge = 2 alors
-            543,65 €
-          sinon si nombre_personnes_à_charge = 3 alors
-            579,29 €
-          sinon
-            617,27 € + 64,34€ * (décimal de (nombre_personnes_à_charge - 4))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 387,40 €
-                -- Couple : 450,57€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors
-              478,02 €
-            sinon si nombre_personnes_à_charge = 2 alors
-              509,57 €
-            sinon si nombre_personnes_à_charge = 3 alors
-              541,10 €
-            sinon
-              576,57 € + 59,71€ * (décimal de (nombre_personnes_à_charge - 4))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 408,14 €
+            -- Couple : 476,32€
           )
+        sinon si nombre_personnes_à_charge = 1 alors
+          507,87 €
+        sinon si nombre_personnes_à_charge = 2 alors
+          543,65 €
+        sinon si nombre_personnes_à_charge = 3 alors
+          579,29 €
+        sinon
+          617,27 € + 64,34€ * (décimal de (nombre_personnes_à_charge - 4))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 387,40 €
+            -- Couple : 450,57€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors
+          478,02 €
+        sinon si nombre_personnes_à_charge = 2 alors
+          509,57 €
+        sinon si nombre_personnes_à_charge = 3 alors
+          541,10 €
+        sinon
+          576,57 € + 59,71€ * (décimal de (nombre_personnes_à_charge - 4))
+      )
 ```
 
 ### Article 34 | LEGIARTI000044137403 [archive]
@@ -3513,9 +3513,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       404,60€ + 58,70€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        356,30€ + 51,86€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      356,30€ + 51,86€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          329,56€ + 47,23€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      329,56€ + 47,23€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 ### Article 8 | LEGIARTI000042378446 [archive]
@@ -3844,9 +3844,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       303,45€ + 44,03€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        267,23€ + 38,90€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      267,23€ + 38,90€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          247,17€ + 35,42€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      247,17€ + 35,42€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 2° Le montant forfaitaire au titre des charges est fixé comme suit (en euros) :
@@ -3993,39 +3993,39 @@ champ d'application CalculAidePersonnaliséeLogementFoyer
           683,5 € + 70,89€ * (décimal de (nombre_personnes_à_charge - 4))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 406,43 €
-              -- Couple : 474,33€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors
-            505,75 €
-          sinon si nombre_personnes_à_charge = 2 alors
-            541,38 €
-          sinon si nombre_personnes_à_charge = 3 alors
-            576,87 €
-          sinon
-            614,69 € + 64,07€ * (décimal de (nombre_personnes_à_charge - 4))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 385,78 €
-                -- Couple : 448,69€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors
-              476,02 €
-            sinon si nombre_personnes_à_charge = 2 alors
-              507,44 €
-            sinon si nombre_personnes_à_charge = 3 alors
-              538,84 €
-            sinon
-              574,16 € + 59,46€ * (décimal de (nombre_personnes_à_charge - 4))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 406,43 €
+            -- Couple : 474,33€
           )
+        sinon si nombre_personnes_à_charge = 1 alors
+          505,75 €
+        sinon si nombre_personnes_à_charge = 2 alors
+          541,38 €
+        sinon si nombre_personnes_à_charge = 3 alors
+          576,87 €
+        sinon
+          614,69 € + 64,07€ * (décimal de (nombre_personnes_à_charge - 4))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 385,78 €
+            -- Couple : 448,69€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors
+          476,02 €
+        sinon si nombre_personnes_à_charge = 2 alors
+          507,44 €
+        sinon si nombre_personnes_à_charge = 3 alors
+          538,84 €
+        sinon
+          574,16 € + 59,46€ * (décimal de (nombre_personnes_à_charge - 4))
+      )
 ```
 
 ### Article 34 | LEGIARTI000042378426 [archive]

--- a/tests/fr/arrete_2019-09-27.catala_fr.result
+++ b/tests/fr/arrete_2019-09-27.catala_fr.result
@@ -140,9 +140,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       435,24€ + 63,15€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        383,28€ + 55,79€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      383,28€ + 55,79€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          354,51€ + 50,81€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      354,51€ + 50,81€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 ### Article 8 | LEGIARTI000048109313
@@ -594,9 +594,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone1 :
       326,43€ + 47,36€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone2 :
-        287,46€ + 41,84€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      287,46€ + 41,84€ * multiplicateur_majoration_plafond_loyer_d823_16_2
     -- Zone3 :
-          265,88€ + 38,11€ * multiplicateur_majoration_plafond_loyer_d823_16_2
+      265,88€ + 38,11€ * multiplicateur_majoration_plafond_loyer_d823_16_2
 ```
 
 2° Le montant forfaitaire au titre des charges est fixé comme suit (en euros) :
@@ -682,33 +682,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1860 €
-                -- Couple : 2239€
-              )
-            sinon
-              (
-                2618 €
-                + 379€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1736 €
-                  -- Couple : 2082€
-                )
-              sinon
-                (
-                  2428 €
-                  + 356€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1860 €
+              -- Couple : 2239€
             )
+          sinon
+            (
+              2618 €
+              + 379€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1736 €
+              -- Couple : 2082€
+            )
+          sinon
+            (
+              2428 €
+              + 356€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 ```
@@ -749,33 +749,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1496 €
-                -- Couple : 1801€
-              )
-            sinon
-              (
-                2106 €
-                + 305€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1397 €
-                  -- Couple : 1676€
-                )
-              sinon
-                (
-                  1955 €
-                  + 279€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1496 €
+              -- Couple : 1801€
             )
+          sinon
+            (
+              2106 €
+              + 305€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1397 €
+              -- Couple : 1676€
+            )
+          sinon
+            (
+              1955 €
+              + 279€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 ```
@@ -817,33 +817,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1642 €
-                -- Couple : 1977€
-              )
-            sinon
-              (
-                2312 €
-                + 335€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1532 €
-                  -- Couple : 1837€
-                )
-              sinon
-                (
-                  2142 €
-                  + 305€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1642 €
+              -- Couple : 1977€
             )
+          sinon
+            (
+              2312 €
+              + 335€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1532 €
+              -- Couple : 1837€
+            )
+          sinon
+            (
+              2142 €
+              + 305€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 ```
@@ -884,33 +884,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1320 €
-                -- Couple : 1589€
-              )
-            sinon
-              (
-                1858 €
-                + 269€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1233 €
-                  -- Couple : 1479€
-                )
-              sinon
-                (
-                  1725 €
-                  + 246€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1320 €
+              -- Couple : 1589€
             )
+          sinon
+            (
+              1858 €
+              + 269€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1233 €
+              -- Couple : 1479€
+            )
+          sinon
+            (
+              1725 €
+              + 246€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 ```
@@ -1231,33 +1231,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1860 €
-                -- Couple : 2239€
-              )
-            sinon
-              (
-                2618 €
-                + 379€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1736 €
-                  -- Couple : 2082€
-                )
-              sinon
-                (
-                  2428 €
-                  + 346€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1860 €
+              -- Couple : 2239€
             )
+          sinon
+            (
+              2618 €
+              + 379€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1736 €
+              -- Couple : 2082€
+            )
+          sinon
+            (
+              2428 €
+              + 346€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1286,33 +1286,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1496 €
-                -- Couple : 1801€
-              )
-            sinon
-              (
-                2106 €
-                + 305€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1397 €
-                  -- Couple : 1676 €
-                )
-              sinon
-                (
-                  1955 €
-                  + 279€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1496 €
+              -- Couple : 1801€
             )
+          sinon
+            (
+              2106 €
+              + 305€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1397 €
+              -- Couple : 1676 €
+            )
+          sinon
+            (
+              1955 €
+              + 279€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1341,33 +1341,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1768 €
-                -- Couple : 2128€
-              )
-            sinon
-              (
-                2488 €
-                + 360€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1650 €
-                  -- Couple : 1979€
-                )
-              sinon
-                (
-                  2308 €
-                  + 329€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1768 €
+              -- Couple : 2128€
             )
+          sinon
+            (
+              2488 €
+              + 360€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1650 €
+              -- Couple : 1979€
+            )
+          sinon
+            (
+              2308 €
+              + 329€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1396,33 +1396,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1422 €
-                -- Couple : 1712€
-              )
-            sinon
-              (
-                2002 €
-                + 290€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1328 €
-                  -- Couple : 1593€
-                )
-              sinon
-                (
-                  1858 €
-                  + 265€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1422 €
+              -- Couple : 1712€
             )
+          sinon
+            (
+              2002 €
+              + 290€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1328 €
+              -- Couple : 1593€
+            )
+          sinon
+            (
+              1858 €
+              + 265€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1451,33 +1451,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1786 €
-                -- Couple : 2150€
-              )
-            sinon
-              (
-                2514 €
-                + 364€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1667 €
-                  -- Couple : 1999€
-                )
-              sinon
-                (
-                  2331 €
-                  + 332€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1786 €
+              -- Couple : 2150€
             )
+          sinon
+            (
+              2514 €
+              + 364€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1667 €
+              -- Couple : 1999€
+            )
+          sinon
+            (
+              2331 €
+              + 332€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1506,33 +1506,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1436 €
-                -- Couple : 1729€
-              )
-            sinon
-              (
-                2022 €
-                + 293€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1341 €
-                  -- Couple : 1609€
-                )
-              sinon
-                (
-                  1877 €
-                  + 268€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1436 €
+              -- Couple : 1729€
             )
+          sinon
+            (
+              2022 €
+              + 293€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1341 €
+              -- Couple : 1609€
+            )
+          sinon
+            (
+              1877 €
+              + 268€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1561,33 +1561,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1807 €
-                -- Couple : 2175€
-              )
-            sinon
-              (
-                2543 €
-                + 368€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1687 €
-                  -- Couple : 2023€
-                )
-              sinon
-                (
-                  2359 €
-                  + 336€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1807 €
+              -- Couple : 2175€
             )
+          sinon
+            (
+              2543 €
+              + 368€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1687 €
+              -- Couple : 2023€
+            )
+          sinon
+            (
+              2359 €
+              + 336€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1616,33 +1616,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 275,48€
-                -- Couple : 331,48€
-              )
-            sinon
-              (
-                387,68€
-                + 56,1€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 257,18€
-                  -- Couple : 308,4€
-                )
-              sinon
-                (
-                  359,62€
-                  + 51,22€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 275,48€
+              -- Couple : 331,48€
             )
+          sinon
+            (
+              387,68€
+              + 56,1€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 257,18€
+              -- Couple : 308,4€
+            )
+          sinon
+            (
+              359,62€
+              + 51,22€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -1670,33 +1670,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1453€
-                -- Couple : 1750€
-              )
-            sinon
-              (
-                2047€
-                + 297€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1357€
-                  -- Couple : 1628€
-                )
-              sinon
-                (
-                  1899€
-                  + 271€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1453€
+              -- Couple : 1750€
             )
+          sinon
+            (
+              2047€
+              + 297€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1357€
+              -- Couple : 1628€
+            )
+          sinon
+            (
+              1899€
+              + 271€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
     * taux_francs_vers_euros
 
@@ -1725,33 +1725,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 221,51€
-                -- Couple : 266,79€
-              )
-            sinon
-              (
-                312,07€
-                + 45,28€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 206,87€
-                  -- Couple : 248,18€
-                )
-              sinon
-                (
-                  289,49€
-                  + 41,31€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 221,51€
+              -- Couple : 266,79€
             )
+          sinon
+            (
+              312,07€
+              + 45,28€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 206,87€
+              -- Couple : 248,18€
+            )
+          sinon
+            (
+              289,49€
+              + 41,31€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -1779,33 +1779,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 278,79€
-                -- Couple : 335,56€
-              )
-            sinon
-              (
-                392,33€
-                + 56,77€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 260,27€
-                  -- Couple : 312,1€
-                )
-              sinon
-                (
-                  363,93€
-                  + 51,83€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 278,79€
+              -- Couple : 335,56€
             )
+          sinon
+            (
+              392,33€
+              + 56,77€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 260,27€
+              -- Couple : 312,1€
+            )
+          sinon
+            (
+              363,93€
+              + 51,83€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -1833,33 +1833,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 224,17€
-                -- Couple : 269,99€
-              )
-            sinon
-              (
-                315,81€
-                + 45,82€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 209,35€
-                  -- Couple : 251,16€
-                )
-              sinon
-                (
-                  292,97€
-                  + 41,81€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 224,17€
+              -- Couple : 269,99€
             )
+          sinon
+            (
+              315,81€
+              + 45,82€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 209,35€
+              -- Couple : 251,16€
+            )
+          sinon
+            (
+              292,97€
+              + 41,81€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -1887,33 +1887,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 282,14€
-                -- Couple : 339,59€
-              )
-            sinon
-              (
-                397,04€
-                + 57,45€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 263,39€
-                  -- Couple : 315,84€
-                )
-              sinon
-                (
-                  368,29€
-                  + 52,45€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 282,14€
+              -- Couple : 339,59€
             )
+          sinon
+            (
+              397,04€
+              + 57,45€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 263,39€
+              -- Couple : 315,84€
+            )
+          sinon
+            (
+              368,29€
+              + 52,45€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -1941,33 +1941,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 226,86€
-                -- Couple : 273,23€
-              )
-            sinon
-              (
-                319,6€
-                + 46,37€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 211,86€
-                  -- Couple : 254,17€
-                )
-              sinon
-                (
-                  296,48€
-                  + 42,31€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 226,86€
+              -- Couple : 273,23€
             )
+          sinon
+            (
+              319,6€
+              + 46,37€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 211,86€
+              -- Couple : 254,17€
+            )
+          sinon
+            (
+              296,48€
+              + 42,31€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -1995,33 +1995,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 287,22€
-                -- Couple : 345,7€
-              )
-            sinon
-              (
-                404,18€
-                + 58,48€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 268,13€
-                  -- Couple : 321,52€
-                )
-              sinon
-                (
-                  374,91€
-                  + 53,39€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 287,22€
+              -- Couple : 345,7€
             )
+          sinon
+            (
+              404,18€
+              + 58,48€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 268,13€
+              -- Couple : 321,52€
+            )
+          sinon
+            (
+              374,91€
+              + 53,39€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2049,33 +2049,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 230,94€
-                -- Couple : 278,14€
-              )
-            sinon
-              (
-                325,34€
-                + 47,2€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 215,67€
-                  -- Couple : 258,74€
-                )
-              sinon
-                (
-                  301,81€
-                  + 43,07€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 230,94€
+              -- Couple : 278,14€
             )
+          sinon
+            (
+              325,34€
+              + 47,2€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 215,67€
+              -- Couple : 258,74€
+            )
+          sinon
+            (
+              301,81€
+              + 43,07€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2103,33 +2103,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 295,26€
-                -- Couple : 355,38€
-              )
-            sinon
-              (
-                415,5€
-                + 60,12€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 275,64€
-                  -- Couple : 330,52€
-                )
-              sinon
-                (
-                  385,41€
-                  + 54,88€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 295,26€
+              -- Couple : 355,38€
             )
+          sinon
+            (
+              415,5€
+              + 60,12€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 275,64€
+              -- Couple : 330,52€
+            )
+          sinon
+            (
+              385,41€
+              + 54,88€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2157,33 +2157,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 237,41€
-                -- Couple : 285,93€
-              )
-            sinon
-              (
-                334,45€
-                + 48,52€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 221,71€
-                  -- Couple : 365,98€
-                )
-              sinon
-                (
-                  310,26€
-                  + 44,28€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 237,41€
+              -- Couple : 285,93€
             )
+          sinon
+            (
+              334,45€
+              + 48,52€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 221,71€
+              -- Couple : 365,98€
+            )
+          sinon
+            (
+              310,26€
+              + 44,28€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2211,33 +2211,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 303,41€
-                -- Couple : 365,19€
-              )
-            sinon
-              (
-                426,97€
-                + 61,78€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 283,25€
-                  -- Couple : 339,64€
-                )
-              sinon
-                (
-                  396,05€
-                  + 56,39€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 303,41€
+              -- Couple : 365,19€
             )
+          sinon
+            (
+              426,97€
+              + 61,78€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 283,25€
+              -- Couple : 339,64€
+            )
+          sinon
+            (
+              396,05€
+              + 56,39€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2265,33 +2265,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 243,96€
-                -- Couple : 293,82€
-              )
-            sinon
-              (
-                343,68€
-                + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 227,83€
-                  -- Couple : 273,32€
-                )
-              sinon
-                (
-                  318,82€
-                  + 45,5€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 243,96€
+              -- Couple : 293,82€
             )
+          sinon
+            (
+              343,68€
+              + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 227,83€
+              -- Couple : 273,32€
+            )
+          sinon
+            (
+              318,82€
+              + 45,5€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2319,33 +2319,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 312,36€
-                -- Couple : 375,96€
-              )
-            sinon
-              (
-                439,57€
-                + 63,6€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 291,61€
-                  -- Couple : 349,66€
-                )
-              sinon
-                (
-                  407,73€
-                  + 58,05€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 312,36€
+              -- Couple : 375,96€
             )
+          sinon
+            (
+              439,57€
+              + 63,6€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 291,61€
+              -- Couple : 349,66€
+            )
+          sinon
+            (
+              407,73€
+              + 58,05€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2373,33 +2373,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 251,16€
-                -- Couple : 302,49€
-              )
-            sinon
-              (
-                353,82€
-                + 51,33€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 234,55€
-                  -- Couple : 281,38€
-                )
-              sinon
-                (
-                  328,23€
-                  + 46,84€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 251,16€
+              -- Couple : 302,49€
             )
+          sinon
+            (
+              353,82€
+              + 51,33€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 234,55€
+              -- Couple : 281,38€
+            )
+          sinon
+            (
+              328,23€
+              + 46,84€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2427,33 +2427,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 313,36€
-                -- Couple : 377,16€
-              )
-            sinon
-              (
-                440,98€
-                + 63,8€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 292,54€
-                  -- Couple : 350,78€
-                )
-              sinon
-                (
-                  409,03€
-                  + 58,24€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 313,36€
+              -- Couple : 377,16€
             )
+          sinon
+            (
+              440,98€
+              + 63,8€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 292,54€
+              -- Couple : 350,78€
+            )
+          sinon
+            (
+              409,03€
+              + 58,24€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2481,33 +2481,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 251,96€
-                -- Couple : 303,46€
-              )
-            sinon
-              (
-                354,95€
-                + 51,49€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 235,3€
-                  -- Couple : 282,28€
-                )
-              sinon
-                (
-                  329,28€
-                  + 46,99€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 251,96€
+              -- Couple : 303,46€
             )
+          sinon
+            (
+              354,95€
+              + 51,49€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 235,3€
+              -- Couple : 282,28€
+            )
+          sinon
+            (
+              329,28€
+              + 46,99€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2535,33 +2535,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 316,81€
-                -- Couple : 381,31€
-              )
-            sinon
-              (
-                445,83€
-                + 64,5€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 295,76€
-                  -- Couple : 354,64€
-                )
-              sinon
-                (
-                  413,53€
-                  + 58,88€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 316,81€
+              -- Couple : 381,31€
             )
+          sinon
+            (
+              445,83€
+              + 64,5€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 295,76€
+              -- Couple : 354,64€
+            )
+          sinon
+            (
+              413,53€
+              + 58,88€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2589,33 +2589,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 254,73€
-                -- Couple : 306,8€
-              )
-            sinon
-              (
-                358,85€
-                + 52,06€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 237,89€
-                  -- Couple : 285,39€
-                )
-              sinon
-                (
-                  332,9€
-                  + 47,51€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 254,73€
+              -- Couple : 306,8€
             )
+          sinon
+            (
+              358,85€
+              + 52,06€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 237,89€
+              -- Couple : 285,39€
+            )
+          sinon
+            (
+              332,9€
+              + 47,51€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2643,33 +2643,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 319,98€
-                -- Couple : 385,12€
-              )
-            sinon
-              (
-                450,29€
-                + 65,15€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 298,72€
-                  -- Couple : 358,19€
-                )
-              sinon
-                (
-                  417,67€
-                  + 59,47€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 319,98€
+              -- Couple : 385,12€
             )
+          sinon
+            (
+              450,29€
+              + 65,15€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 298,72€
+              -- Couple : 358,19€
+            )
+          sinon
+            (
+              417,67€
+              + 59,47€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2697,33 +2697,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 257,28€
-                -- Couple : 309,87€
-              )
-            sinon
-              (
-                362,44€
-                + 52,58€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 240,27€
-                  -- Couple : 288,24€
-                )
-              sinon
-                (
-                  336,23€
-                  + 47,99€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 257,28€
+              -- Couple : 309,87€
             )
+          sinon
+            (
+              362,44€
+              + 52,58€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 240,27€
+              -- Couple : 288,24€
+            )
+          sinon
+            (
+              336,23€
+              + 47,99€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2751,33 +2751,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 326,86€
-                -- Couple : 393,4€
-              )
-            sinon
-              (
-                459,97€
-                + 66,55€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 305,14€
-                  -- Couple : 365,89€
-                )
-              sinon
-                (
-                  426,65€
-                  + 60,75€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 326,86€
+              -- Couple : 393,4€
             )
+          sinon
+            (
+              459,97€
+              + 66,55€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 305,14€
+              -- Couple : 365,89€
+            )
+          sinon
+            (
+              426,65€
+              + 60,75€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2805,33 +2805,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 262,81€
-                -- Couple : 316,53€
-              )
-            sinon
-              (
-                370,23€
-                + 53,71€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 245,44€
-                  -- Couple : 294,44€
-                )
-              sinon
-                (
-                  343,46€
-                  + 49,02€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 262,81€
+              -- Couple : 316,53€
             )
+          sinon
+            (
+              370,23€
+              + 53,71€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 245,44€
+              -- Couple : 294,44€
+            )
+          sinon
+            (
+              343,46€
+              + 49,02€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2859,33 +2859,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 328,72€
-                -- Couple : 395,64€
-              )
-            sinon
-              (
-                462,59€
-                + 66,93€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 306,88€
-                  -- Couple : 367,98€
-                )
-              sinon
-                (
-                  429,08€
-                  + 61,1€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 328,72€
+              -- Couple : 395,64€
             )
+          sinon
+            (
+              462,59€
+              + 66,93€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 306,88€
+              -- Couple : 367,98€
+            )
+          sinon
+            (
+              429,08€
+              + 61,1€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2913,33 +2913,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 264,31€
-                -- Couple : 318,33€
-              )
-            sinon
-              (
-                372,34€
-                + 54,02€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 246,84€
-                  -- Couple : 296,12€
-                )
-              sinon
-                (
-                  345,42€
-                  + 49,3€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 264,31€
+              -- Couple : 318,33€
             )
+          sinon
+            (
+              372,34€
+              + 54,02€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 246,84€
+              -- Couple : 296,12€
+            )
+          sinon
+            (
+              345,42€
+              + 49,3€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -2967,33 +2967,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 328,98€
-                -- Couple : 395,96€
-              )
-            sinon
-              (
-                462,96€
-                + 66,98€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 307,13€
-                  -- Couple : 368,27€
-                )
-              sinon
-                (
-                  429,42€
-                  + 61,15€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 328,98€
+              -- Couple : 395,96€
             )
+          sinon
+            (
+              462,96€
+              + 66,98€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 307,13€
+              -- Couple : 368,27€
+            )
+          sinon
+            (
+              429,42€
+              + 61,15€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -3021,33 +3021,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 264,52€
-                -- Couple : 318,58€
-              )
-            sinon
-              (
-                372,64€
-                + 54,06€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 247,04€
-                  -- Couple : 296,36€
-                )
-              sinon
-                (
-                  345,7€
-                  + 49,34€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 264,52€
+              -- Couple : 318,58€
             )
+          sinon
+            (
+              372,64€
+              + 54,06€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 247,04€
+              -- Couple : 296,36€
+            )
+          sinon
+            (
+              345,7€
+              + 49,34€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -3075,33 +3075,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 331,45€
-                -- Couple : 398,93€
-              )
-            sinon
-              (
-                466,43€
-                + 67,48€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 309,43€
-                  -- Couple : 371,03€
-                )
-              sinon
-                (
-                  432,64€
-                  + 61,61€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 331,45€
+              -- Couple : 398,93€
             )
+          sinon
+            (
+              466,43€
+              + 67,48€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 309,43€
+              -- Couple : 371,03€
+            )
+          sinon
+            (
+              432,64€
+              + 61,61€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -3129,33 +3129,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 266,5€
-                -- Couple : 320,97€
-              )
-            sinon
-              (
-                375,43€
-                + 54,47€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 248,89€
-                  -- Couple : 298,58€
-                )
-              sinon
-                (
-                  348,29€
-                  + 49,71€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 266,5€
+              -- Couple : 320,97€
             )
+          sinon
+            (
+              375,43€
+              + 54,47€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 248,89€
+              -- Couple : 298,58€
+            )
+          sinon
+            (
+              348,29€
+              + 49,71€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -3182,33 +3182,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 332,44€
-                -- Couple : 400,13€
-              )
-            sinon
-              (
-                467,83€
-                + 67,68€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 310,36€
-                  -- Couple : 372,15€
-                )
-              sinon
-                (
-                  433,94€
-                  + 61,79€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 332,44€
+              -- Couple : 400,13€
             )
+          sinon
+            (
+              467,83€
+              + 67,68€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 310,36€
+              -- Couple : 372,15€
+            )
+          sinon
+            (
+              433,94€
+              + 61,79€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 
   étiquette petit_2
@@ -3235,33 +3235,33 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 267,30€
-                -- Couple : 321,93€
-              )
-            sinon
-              (
-                376,56€
-                + 54,63€ * (décimal de (nombre_personnes_à_charge - 1))
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 249,64€
-                  -- Couple : 299,48€
-                )
-              sinon
-                (
-                  349,34€
-                  + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 267,30€
+              -- Couple : 321,93€
             )
+          sinon
+            (
+              376,56€
+              + 54,63€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 249,64€
+              -- Couple : 299,48€
+            )
+          sinon
+            (
+              349,34€
+              + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
+            )
+        )
     )
 ```
 
@@ -3414,12 +3414,12 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     -- Neuf :
       (si date_signature_prêt <= |1998-10-01| alors 0,0226 sinon 0,0234)
     -- Ancien de amélioré_par_occupant :
-        (
-          selon amélioré_par_occupant sous forme
-          -- AmélioréParOccupant.Oui : 0,0172
-          -- AmélioréParOccupant.Non :
-              (si date_signature_prêt <= |1998-10-01| alors 0,0226 sinon 0,0234)
-        )
+      (
+        selon amélioré_par_occupant sous forme
+        -- AmélioréParOccupant.Oui : 0,0172
+        -- AmélioréParOccupant.Non :
+          (si date_signature_prêt <= |1998-10-01| alors 0,0226 sinon 0,0234)
+      )
 ```
 
 ### Article 26 | LEGIARTI000039160777
@@ -3493,63 +3493,63 @@ champ d'application CalculAidePersonnaliséeLogementFoyer
             )
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 437,20 €
-                -- Couple : 510,24€
-              )
-            sinon
-              (
-                si nombre_personnes_à_charge = 1 alors
-                  544,05 €
-                sinon
-                  (
-                    si nombre_personnes_à_charge = 2 alors
-                      582,37 €
-                    sinon
-                      (
-                        si nombre_personnes_à_charge = 3 alors
-                          620,55 €
-                        sinon
-                          (
-                            661,23 €
-                            + 68,92€ * (décimal de (nombre_personnes_à_charge - 4))
-                          )
-                      )
-                  )
-              )
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 414,99 €
-                  -- Couple : 482,66€
-                )
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 437,20 €
+              -- Couple : 510,24€
+            )
+          sinon
+            (
+              si nombre_personnes_à_charge = 1 alors
+                544,05 €
               sinon
                 (
-                  si nombre_personnes_à_charge = 1 alors
-                    512,07 €
+                  si nombre_personnes_à_charge = 2 alors
+                    582,37 €
                   sinon
                     (
-                      si nombre_personnes_à_charge = 2 alors
-                        545,86 €
+                      si nombre_personnes_à_charge = 3 alors
+                        620,55 €
                       sinon
                         (
-                          si nombre_personnes_à_charge = 3 alors
-                            579,64 €
-                          sinon
-                            (
-                              617,64 €
-                              + 63,96€ * (décimal de (nombre_personnes_à_charge - 4))
-                            )
+                          661,23 €
+                          + 68,92€ * (décimal de (nombre_personnes_à_charge - 4))
                         )
                     )
                 )
             )
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 414,99 €
+              -- Couple : 482,66€
+            )
+          sinon
+            (
+              si nombre_personnes_à_charge = 1 alors
+                512,07 €
+              sinon
+                (
+                  si nombre_personnes_à_charge = 2 alors
+                    545,86 €
+                  sinon
+                    (
+                      si nombre_personnes_à_charge = 3 alors
+                        579,64 €
+                      sinon
+                        (
+                          617,64 €
+                          + 63,96€ * (décimal de (nombre_personnes_à_charge - 4))
+                        )
+                    )
+                )
+            )
+        )
     )
 ```
 
@@ -3970,37 +3970,37 @@ champ d'application CalculAllocationLogementAccessionPropriété
             2280€ + 198€ * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1393 €
-                -- Couple : 1706€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 1847 €
-            sinon si nombre_personnes_à_charge = 2 alors 1912 €
-            sinon si nombre_personnes_à_charge = 3 alors 1977 €
-            sinon si nombre_personnes_à_charge = 4 alors 2042 €
-            sinon si nombre_personnes_à_charge = 5 alors 2187 €
-            sinon
-              2187€ + 191€ * (décimal de (nombre_personnes_à_charge - 5))
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1306 €
-                  -- Couple : 1584€
-                )
-              sinon si nombre_personnes_à_charge = 1 alors 1726 €
-              sinon si nombre_personnes_à_charge = 2 alors 1798 €
-              sinon si nombre_personnes_à_charge = 3 alors 1870 €
-              sinon si nombre_personnes_à_charge = 4 alors 1942 €
-              sinon si nombre_personnes_à_charge = 5 alors 2086 €
-              sinon
-                2086€ + 182€ * (décimal de (nombre_personnes_à_charge - 5))
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1393 €
+              -- Couple : 1706€
             )
+          sinon si nombre_personnes_à_charge = 1 alors 1847 €
+          sinon si nombre_personnes_à_charge = 2 alors 1912 €
+          sinon si nombre_personnes_à_charge = 3 alors 1977 €
+          sinon si nombre_personnes_à_charge = 4 alors 2042 €
+          sinon si nombre_personnes_à_charge = 5 alors 2187 €
+          sinon
+            2187€ + 191€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1306 €
+              -- Couple : 1584€
+            )
+          sinon si nombre_personnes_à_charge = 1 alors 1726 €
+          sinon si nombre_personnes_à_charge = 2 alors 1798 €
+          sinon si nombre_personnes_à_charge = 3 alors 1870 €
+          sinon si nombre_personnes_à_charge = 4 alors 1942 €
+          sinon si nombre_personnes_à_charge = 5 alors 2086 €
+          sinon
+            2086€ + 182€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
     )
     * taux_francs_vers_euros
 
@@ -4028,37 +4028,37 @@ champ d'application CalculAllocationLogementAccessionPropriété
             2305€ + 200€ * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1408 €
-                -- Couple : 1725€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 1867 €
-            sinon si nombre_personnes_à_charge = 2 alors 1933 €
-            sinon si nombre_personnes_à_charge = 3 alors 1999 €
-            sinon si nombre_personnes_à_charge = 4 alors 2065 €
-            sinon si nombre_personnes_à_charge = 5 alors 2211 €
-            sinon
-              2211 € + 193€ * (décimal de (nombre_personnes_à_charge - 5))
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1320 €
-                  -- Couple : 1801€
-                )
-              sinon si nombre_personnes_à_charge = 1 alors 1745 €
-              sinon si nombre_personnes_à_charge = 2 alors 1818 €
-              sinon si nombre_personnes_à_charge = 3 alors 1891 €
-              sinon si nombre_personnes_à_charge = 4 alors 1964 €
-              sinon si nombre_personnes_à_charge = 5 alors 2109 €
-              sinon
-                2109€ + 184€ * (décimal de (nombre_personnes_à_charge - 5))
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1408 €
+              -- Couple : 1725€
             )
+          sinon si nombre_personnes_à_charge = 1 alors 1867 €
+          sinon si nombre_personnes_à_charge = 2 alors 1933 €
+          sinon si nombre_personnes_à_charge = 3 alors 1999 €
+          sinon si nombre_personnes_à_charge = 4 alors 2065 €
+          sinon si nombre_personnes_à_charge = 5 alors 2211 €
+          sinon
+            2211 € + 193€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1320 €
+              -- Couple : 1801€
+            )
+          sinon si nombre_personnes_à_charge = 1 alors 1745 €
+          sinon si nombre_personnes_à_charge = 2 alors 1818 €
+          sinon si nombre_personnes_à_charge = 3 alors 1891 €
+          sinon si nombre_personnes_à_charge = 4 alors 1964 €
+          sinon si nombre_personnes_à_charge = 5 alors 2109 €
+          sinon
+            2109€ + 184€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
     )
     * taux_francs_vers_euros
 
@@ -4086,37 +4086,37 @@ champ d'application CalculAllocationLogementAccessionPropriété
             2346€ + 204€ * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1433 €
-                -- Couple : 1756€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 1901 €
-            sinon si nombre_personnes_à_charge = 2 alors 1966 €
-            sinon si nombre_personnes_à_charge = 3 alors 2035 €
-            sinon si nombre_personnes_à_charge = 4 alors 2102 €
-            sinon si nombre_personnes_à_charge = 5 alors 2251 €
-            sinon
-              2251 € + 196€ * (décimal de (nombre_personnes_à_charge - 5))
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1344 €
-                  -- Couple : 1630€
-                )
-              sinon si nombre_personnes_à_charge = 1 alors 1777 €
-              sinon si nombre_personnes_à_charge = 2 alors 1851 €
-              sinon si nombre_personnes_à_charge = 3 alors 1925 €
-              sinon si nombre_personnes_à_charge = 4 alors 1999 €
-              sinon si nombre_personnes_à_charge = 5 alors 2147 €
-              sinon
-                2147€ + 187€ * (décimal de (nombre_personnes_à_charge - 5))
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1433 €
+              -- Couple : 1756€
             )
+          sinon si nombre_personnes_à_charge = 1 alors 1901 €
+          sinon si nombre_personnes_à_charge = 2 alors 1966 €
+          sinon si nombre_personnes_à_charge = 3 alors 2035 €
+          sinon si nombre_personnes_à_charge = 4 alors 2102 €
+          sinon si nombre_personnes_à_charge = 5 alors 2251 €
+          sinon
+            2251 € + 196€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1344 €
+              -- Couple : 1630€
+            )
+          sinon si nombre_personnes_à_charge = 1 alors 1777 €
+          sinon si nombre_personnes_à_charge = 2 alors 1851 €
+          sinon si nombre_personnes_à_charge = 3 alors 1925 €
+          sinon si nombre_personnes_à_charge = 4 alors 1999 €
+          sinon si nombre_personnes_à_charge = 5 alors 2147 €
+          sinon
+            2147€ + 187€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
     )
     * taux_francs_vers_euros
 
@@ -4144,37 +4144,37 @@ champ d'application CalculAllocationLogementAccessionPropriété
             2402€ + 209€ * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1467 €
-                -- Couple : 1798€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 1947 €
-            sinon si nombre_personnes_à_charge = 2 alors 2015 €
-            sinon si nombre_personnes_à_charge = 3 alors 2084 €
-            sinon si nombre_personnes_à_charge = 4 alors 2152 €
-            sinon si nombre_personnes_à_charge = 5 alors 2305 €
-            sinon
-              2305 € + 201€ * (décimal de (nombre_personnes_à_charge - 5))
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1376 €
-                  -- Couple : 1669€
-                )
-              sinon si nombre_personnes_à_charge = 1 alors 1820 €
-              sinon si nombre_personnes_à_charge = 2 alors 1895 €
-              sinon si nombre_personnes_à_charge = 3 alors 1971 €
-              sinon si nombre_personnes_à_charge = 4 alors 2047 €
-              sinon si nombre_personnes_à_charge = 5 alors 2199 €
-              sinon
-                2199€ + 191€ * (décimal de (nombre_personnes_à_charge - 5))
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1467 €
+              -- Couple : 1798€
             )
+          sinon si nombre_personnes_à_charge = 1 alors 1947 €
+          sinon si nombre_personnes_à_charge = 2 alors 2015 €
+          sinon si nombre_personnes_à_charge = 3 alors 2084 €
+          sinon si nombre_personnes_à_charge = 4 alors 2152 €
+          sinon si nombre_personnes_à_charge = 5 alors 2305 €
+          sinon
+            2305 € + 201€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1376 €
+              -- Couple : 1669€
+            )
+          sinon si nombre_personnes_à_charge = 1 alors 1820 €
+          sinon si nombre_personnes_à_charge = 2 alors 1895 €
+          sinon si nombre_personnes_à_charge = 3 alors 1971 €
+          sinon si nombre_personnes_à_charge = 4 alors 2047 €
+          sinon si nombre_personnes_à_charge = 5 alors 2199 €
+          sinon
+            2199€ + 191€ * (décimal de (nombre_personnes_à_charge - 5))
+        )
     )
     * taux_francs_vers_euros
 
@@ -4204,41 +4204,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
             * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1468 €
-                -- Couple : 1800€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 1949 €
-            sinon si nombre_personnes_à_charge = 2 alors 2017 €
-            sinon si nombre_personnes_à_charge = 3 alors 2086 €
-            sinon si nombre_personnes_à_charge = 4 alors 2154 €
-            sinon si nombre_personnes_à_charge = 5 alors 2307 €
-            sinon
-              2307 €
-              + 201€
-              * (décimal de (nombre_personnes_à_charge - 5))
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1377 €
-                  -- Couple : 1671€
-                )
-              sinon si nombre_personnes_à_charge = 1 alors 1822 €
-              sinon si nombre_personnes_à_charge = 2 alors 1897 €
-              sinon si nombre_personnes_à_charge = 3 alors 1973 €
-              sinon si nombre_personnes_à_charge = 4 alors 2049 €
-              sinon si nombre_personnes_à_charge = 5 alors 2201 €
-              sinon
-                2201€
-                + 191€
-                * (décimal de (nombre_personnes_à_charge - 5))
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1468 €
+              -- Couple : 1800€
             )
+          sinon si nombre_personnes_à_charge = 1 alors 1949 €
+          sinon si nombre_personnes_à_charge = 2 alors 2017 €
+          sinon si nombre_personnes_à_charge = 3 alors 2086 €
+          sinon si nombre_personnes_à_charge = 4 alors 2154 €
+          sinon si nombre_personnes_à_charge = 5 alors 2307 €
+          sinon
+            2307 €
+            + 201€
+            * (décimal de (nombre_personnes_à_charge - 5))
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1377 €
+              -- Couple : 1671€
+            )
+          sinon si nombre_personnes_à_charge = 1 alors 1822 €
+          sinon si nombre_personnes_à_charge = 2 alors 1897 €
+          sinon si nombre_personnes_à_charge = 3 alors 1973 €
+          sinon si nombre_personnes_à_charge = 4 alors 2049 €
+          sinon si nombre_personnes_à_charge = 5 alors 2201 €
+          sinon
+            2201€
+            + 191€
+            * (décimal de (nombre_personnes_à_charge - 5))
+        )
     )
     * taux_francs_vers_euros
 
@@ -4268,41 +4268,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
             * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1483 €
-                -- Couple : 1818€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 1968 €
-            sinon si nombre_personnes_à_charge = 2 alors 2037 €
-            sinon si nombre_personnes_à_charge = 3 alors 2107 €
-            sinon si nombre_personnes_à_charge = 4 alors 2176 €
-            sinon si nombre_personnes_à_charge = 5 alors 2330 €
-            sinon
-              2330 €
-              + 203€
-              * (décimal de (nombre_personnes_à_charge - 5))
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1391 €
-                  -- Couple : 1688€
-                )
-              sinon si nombre_personnes_à_charge = 1 alors 1840 €
-              sinon si nombre_personnes_à_charge = 2 alors 1916 €
-              sinon si nombre_personnes_à_charge = 3 alors 1993 €
-              sinon si nombre_personnes_à_charge = 4 alors 2069 €
-              sinon si nombre_personnes_à_charge = 5 alors 2223 €
-              sinon
-                2223€
-                + 193€
-                * (décimal de (nombre_personnes_à_charge - 5))
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1483 €
+              -- Couple : 1818€
             )
+          sinon si nombre_personnes_à_charge = 1 alors 1968 €
+          sinon si nombre_personnes_à_charge = 2 alors 2037 €
+          sinon si nombre_personnes_à_charge = 3 alors 2107 €
+          sinon si nombre_personnes_à_charge = 4 alors 2176 €
+          sinon si nombre_personnes_à_charge = 5 alors 2330 €
+          sinon
+            2330 €
+            + 203€
+            * (décimal de (nombre_personnes_à_charge - 5))
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1391 €
+              -- Couple : 1688€
+            )
+          sinon si nombre_personnes_à_charge = 1 alors 1840 €
+          sinon si nombre_personnes_à_charge = 2 alors 1916 €
+          sinon si nombre_personnes_à_charge = 3 alors 1993 €
+          sinon si nombre_personnes_à_charge = 4 alors 2069 €
+          sinon si nombre_personnes_à_charge = 5 alors 2223 €
+          sinon
+            2223€
+            + 193€
+            * (décimal de (nombre_personnes_à_charge - 5))
+        )
     )
     * taux_francs_vers_euros
 
@@ -4332,41 +4332,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
             * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
-          (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 1501 €
-                -- Couple : 1840€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 1992 €
-            sinon si nombre_personnes_à_charge = 2 alors 2061 €
-            sinon si nombre_personnes_à_charge = 3 alors 2132 €
-            sinon si nombre_personnes_à_charge = 4 alors 2202 €
-            sinon si nombre_personnes_à_charge = 5 alors 2358 €
-            sinon
-              2358 €
-              + 205€
-              * (décimal de (nombre_personnes_à_charge - 5))
-          )
-      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
             (
-              si nombre_personnes_à_charge = 0 alors
-                (
-                  selon situation_familiale_calcul_apl sous forme
-                  -- PersonneSeule : 1408 €
-                  -- Couple : 1708€
-                )
-              sinon si nombre_personnes_à_charge = 1 alors 1862 €
-              sinon si nombre_personnes_à_charge = 2 alors 1939 €
-              sinon si nombre_personnes_à_charge = 3 alors 2017 €
-              sinon si nombre_personnes_à_charge = 4 alors 2094 €
-              sinon si nombre_personnes_à_charge = 5 alors 2250 €
-              sinon
-                2250€
-                + 195€
-                * (décimal de (nombre_personnes_à_charge - 5))
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1501 €
+              -- Couple : 1840€
             )
+          sinon si nombre_personnes_à_charge = 1 alors 1992 €
+          sinon si nombre_personnes_à_charge = 2 alors 2061 €
+          sinon si nombre_personnes_à_charge = 3 alors 2132 €
+          sinon si nombre_personnes_à_charge = 4 alors 2202 €
+          sinon si nombre_personnes_à_charge = 5 alors 2358 €
+          sinon
+            2358 €
+            + 205€
+            * (décimal de (nombre_personnes_à_charge - 5))
+        )
+      -- Zone3 :
+        (
+          si nombre_personnes_à_charge = 0 alors
+            (
+              selon situation_familiale_calcul_apl sous forme
+              -- PersonneSeule : 1408 €
+              -- Couple : 1708€
+            )
+          sinon si nombre_personnes_à_charge = 1 alors 1862 €
+          sinon si nombre_personnes_à_charge = 2 alors 1939 €
+          sinon si nombre_personnes_à_charge = 3 alors 2017 €
+          sinon si nombre_personnes_à_charge = 4 alors 2094 €
+          sinon si nombre_personnes_à_charge = 5 alors 2250 €
+          sinon
+            2250€
+            + 195€
+            * (décimal de (nombre_personnes_à_charge - 5))
+        )
     )
     * taux_francs_vers_euros
 
@@ -4395,41 +4395,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 228,83 €
-              -- Couple : 280,51€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 303,68 €
-          sinon si nombre_personnes_à_charge = 2 alors 314,20 €
-          sinon si nombre_personnes_à_charge = 3 alors 325,02 €
-          sinon si nombre_personnes_à_charge = 4 alors 335,69 €
-          sinon si nombre_personnes_à_charge = 5 alors 359,47 €
-          sinon
-            359,47 €
-            + 31,25€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 214,65 €
-                -- Couple : 260,38€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 283,86 €
-            sinon si nombre_personnes_à_charge = 2 alors 295,60 €
-            sinon si nombre_personnes_à_charge = 3 alors 307,49 €
-            sinon si nombre_personnes_à_charge = 4 alors 319,23 €
-            sinon si nombre_personnes_à_charge = 5 alors 343,01 €
-            sinon
-              343,01€
-              + 29,73€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 228,83 €
+            -- Couple : 280,51€
           )
+        sinon si nombre_personnes_à_charge = 1 alors 303,68 €
+        sinon si nombre_personnes_à_charge = 2 alors 314,20 €
+        sinon si nombre_personnes_à_charge = 3 alors 325,02 €
+        sinon si nombre_personnes_à_charge = 4 alors 335,69 €
+        sinon si nombre_personnes_à_charge = 5 alors 359,47 €
+        sinon
+          359,47 €
+          + 31,25€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 214,65 €
+            -- Couple : 260,38€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 283,86 €
+        sinon si nombre_personnes_à_charge = 2 alors 295,60 €
+        sinon si nombre_personnes_à_charge = 3 alors 307,49 €
+        sinon si nombre_personnes_à_charge = 4 alors 319,23 €
+        sinon si nombre_personnes_à_charge = 5 alors 343,01 €
+        sinon
+          343,01€
+          + 29,73€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4456,41 +4456,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 231,58 €
-              -- Couple : 283,88€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 307,32 €
-          sinon si nombre_personnes_à_charge = 2 alors 317,97 €
-          sinon si nombre_personnes_à_charge = 3 alors 328,92 €
-          sinon si nombre_personnes_à_charge = 4 alors 339,72 €
-          sinon si nombre_personnes_à_charge = 5 alors 363,78 €
-          sinon
-            363,78 €
-            + 31,63€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 217,23 €
-                -- Couple : 263,50€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 287,27 €
-            sinon si nombre_personnes_à_charge = 2 alors 299,15 €
-            sinon si nombre_personnes_à_charge = 3 alors 311,18 €
-            sinon si nombre_personnes_à_charge = 4 alors 323,06 €
-            sinon si nombre_personnes_à_charge = 5 alors 347,13 €
-            sinon
-              347,13€
-              + 30,09€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 231,58 €
+            -- Couple : 283,88€
           )
+        sinon si nombre_personnes_à_charge = 1 alors 307,32 €
+        sinon si nombre_personnes_à_charge = 2 alors 317,97 €
+        sinon si nombre_personnes_à_charge = 3 alors 328,92 €
+        sinon si nombre_personnes_à_charge = 4 alors 339,72 €
+        sinon si nombre_personnes_à_charge = 5 alors 363,78 €
+        sinon
+          363,78 €
+          + 31,63€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 217,23 €
+            -- Couple : 263,50€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 287,27 €
+        sinon si nombre_personnes_à_charge = 2 alors 299,15 €
+        sinon si nombre_personnes_à_charge = 3 alors 311,18 €
+        sinon si nombre_personnes_à_charge = 4 alors 323,06 €
+        sinon si nombre_personnes_à_charge = 5 alors 347,13 €
+        sinon
+          347,13€
+          + 30,09€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4517,41 +4517,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 234,36 €
-              -- Couple : 287,29€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 311,01 €
-          sinon si nombre_personnes_à_charge = 2 alors 321,79 €
-          sinon si nombre_personnes_à_charge = 3 alors 332,87 €
-          sinon si nombre_personnes_à_charge = 4 alors 343,80 €
-          sinon si nombre_personnes_à_charge = 5 alors 368,15 €
-          sinon
-            368,15 €
-            + 32,01€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 219,84 €
-                -- Couple : 266,66€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 290,72 €
-            sinon si nombre_personnes_à_charge = 2 alors 302,74 €
-            sinon si nombre_personnes_à_charge = 3 alors 314,91 €
-            sinon si nombre_personnes_à_charge = 4 alors 326,94 €
-            sinon si nombre_personnes_à_charge = 5 alors 351,30 €
-            sinon
-              351,30€
-              + 30,45€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 234,36 €
+            -- Couple : 287,29€
           )
+        sinon si nombre_personnes_à_charge = 1 alors 311,01 €
+        sinon si nombre_personnes_à_charge = 2 alors 321,79 €
+        sinon si nombre_personnes_à_charge = 3 alors 332,87 €
+        sinon si nombre_personnes_à_charge = 4 alors 343,80 €
+        sinon si nombre_personnes_à_charge = 5 alors 368,15 €
+        sinon
+          368,15 €
+          + 32,01€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 219,84 €
+            -- Couple : 266,66€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 290,72 €
+        sinon si nombre_personnes_à_charge = 2 alors 302,74 €
+        sinon si nombre_personnes_à_charge = 3 alors 314,91 €
+        sinon si nombre_personnes_à_charge = 4 alors 326,94 €
+        sinon si nombre_personnes_à_charge = 5 alors 351,30 €
+        sinon
+          351,30€
+          + 30,45€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4578,41 +4578,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 238,58 €
-              -- Couple : 292,46€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 316,61 €
-          sinon si nombre_personnes_à_charge = 2 alors 327,58 €
-          sinon si nombre_personnes_à_charge = 3 alors 338,86 €
-          sinon si nombre_personnes_à_charge = 4 alors 349,99 €
-          sinon si nombre_personnes_à_charge = 5 alors 374,78 €
-          sinon
-            374,78 €
-            + 32,59€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 223,80 €
-                -- Couple : 271,46€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 295,95 €
-            sinon si nombre_personnes_à_charge = 2 alors 308,19 €
-            sinon si nombre_personnes_à_charge = 3 alors 320,58 €
-            sinon si nombre_personnes_à_charge = 4 alors 332,82 €
-            sinon si nombre_personnes_à_charge = 5 alors 357,62 €
-            sinon
-              357,62€
-              + 31,00€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 238,58 €
+            -- Couple : 292,46€
           )
+        sinon si nombre_personnes_à_charge = 1 alors 316,61 €
+        sinon si nombre_personnes_à_charge = 2 alors 327,58 €
+        sinon si nombre_personnes_à_charge = 3 alors 338,86 €
+        sinon si nombre_personnes_à_charge = 4 alors 349,99 €
+        sinon si nombre_personnes_à_charge = 5 alors 374,78 €
+        sinon
+          374,78 €
+          + 32,59€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 223,80 €
+            -- Couple : 271,46€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 295,95 €
+        sinon si nombre_personnes_à_charge = 2 alors 308,19 €
+        sinon si nombre_personnes_à_charge = 3 alors 320,58 €
+        sinon si nombre_personnes_à_charge = 4 alors 332,82 €
+        sinon si nombre_personnes_à_charge = 5 alors 357,62 €
+        sinon
+          357,62€
+          + 31,00€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4639,41 +4639,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 245,26 €
-              -- Couple : 300,65€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 325,48 €
-          sinon si nombre_personnes_à_charge = 2 alors 336,75 €
-          sinon si nombre_personnes_à_charge = 3 alors 348,65 €
-          sinon si nombre_personnes_à_charge = 4 alors 359,79 €
-          sinon si nombre_personnes_à_charge = 5 alors 385,27 €
-          sinon
-            385,27 €
-            + 33,50€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 230,07 €
-                -- Couple : 279,06€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 304,24 €
-            sinon si nombre_personnes_à_charge = 2 alors 316,82 €
-            sinon si nombre_personnes_à_charge = 3 alors 329,56 €
-            sinon si nombre_personnes_à_charge = 4 alors 342,14 €
-            sinon si nombre_personnes_à_charge = 5 alors 367,33 €
-            sinon
-              367,33€
-              + 31,87€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 245,26 €
+            -- Couple : 300,65€
           )
+        sinon si nombre_personnes_à_charge = 1 alors 325,48 €
+        sinon si nombre_personnes_à_charge = 2 alors 336,75 €
+        sinon si nombre_personnes_à_charge = 3 alors 348,65 €
+        sinon si nombre_personnes_à_charge = 4 alors 359,79 €
+        sinon si nombre_personnes_à_charge = 5 alors 385,27 €
+        sinon
+          385,27 €
+          + 33,50€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 230,07 €
+            -- Couple : 279,06€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 304,24 €
+        sinon si nombre_personnes_à_charge = 2 alors 316,82 €
+        sinon si nombre_personnes_à_charge = 3 alors 329,56 €
+        sinon si nombre_personnes_à_charge = 4 alors 342,14 €
+        sinon si nombre_personnes_à_charge = 5 alors 367,33 €
+        sinon
+          367,33€
+          + 31,87€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4700,41 +4700,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 252,03 €
-              -- Couple : 308,95€
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 334,46 €
-          sinon si nombre_personnes_à_charge = 2 alors 346,04 €
-          sinon si nombre_personnes_à_charge = 3 alors 357,96 €
-          sinon si nombre_personnes_à_charge = 4 alors 369,72 €
-          sinon si nombre_personnes_à_charge = 5 alors 395,90 €
-          sinon
-            395,90 €
-            + 34,42€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 236,42 €
-                -- Couple : 286,76€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 312,64 €
-            sinon si nombre_personnes_à_charge = 2 alors 325,56 €
-            sinon si nombre_personnes_à_charge = 3 alors 338,66 €
-            sinon si nombre_personnes_à_charge = 4 alors 351,58 €
-            sinon si nombre_personnes_à_charge = 5 alors 377,78 €
-            sinon
-              377,78€
-              + 32,75€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 252,03 €
+            -- Couple : 308,95€
           )
+        sinon si nombre_personnes_à_charge = 1 alors 334,46 €
+        sinon si nombre_personnes_à_charge = 2 alors 346,04 €
+        sinon si nombre_personnes_à_charge = 3 alors 357,96 €
+        sinon si nombre_personnes_à_charge = 4 alors 369,72 €
+        sinon si nombre_personnes_à_charge = 5 alors 395,90 €
+        sinon
+          395,90 €
+          + 34,42€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 236,42 €
+            -- Couple : 286,76€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 312,64 €
+        sinon si nombre_personnes_à_charge = 2 alors 325,56 €
+        sinon si nombre_personnes_à_charge = 3 alors 338,66 €
+        sinon si nombre_personnes_à_charge = 4 alors 351,58 €
+        sinon si nombre_personnes_à_charge = 5 alors 377,78 €
+        sinon
+          377,78€
+          + 32,75€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4761,41 +4761,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 259,46 €
-              -- Couple : 318,06 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 344,33 €
-          sinon si nombre_personnes_à_charge = 2 alors 356,25 €
-          sinon si nombre_personnes_à_charge = 3 alors 368,52 €
-          sinon si nombre_personnes_à_charge = 4 alors 380,63 €
-          sinon si nombre_personnes_à_charge = 5 alors 407,58 €
-          sinon
-            407,58 €
-            + 35,44€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 243,39 €
-                -- Couple : 295,22€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 321,86 €
-            sinon si nombre_personnes_à_charge = 2 alors 335,16 €
-            sinon si nombre_personnes_à_charge = 3 alors 348,65 €
-            sinon si nombre_personnes_à_charge = 4 alors 361,95 €
-            sinon si nombre_personnes_à_charge = 5 alors 388,92 €
-            sinon
-              388,92€
-              + 33,72€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 259,46 €
+            -- Couple : 318,06 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 344,33 €
+        sinon si nombre_personnes_à_charge = 2 alors 356,25 €
+        sinon si nombre_personnes_à_charge = 3 alors 368,52 €
+        sinon si nombre_personnes_à_charge = 4 alors 380,63 €
+        sinon si nombre_personnes_à_charge = 5 alors 407,58 €
+        sinon
+          407,58 €
+          + 35,44€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 243,39 €
+            -- Couple : 295,22€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 321,86 €
+        sinon si nombre_personnes_à_charge = 2 alors 335,16 €
+        sinon si nombre_personnes_à_charge = 3 alors 348,65 €
+        sinon si nombre_personnes_à_charge = 4 alors 361,95 €
+        sinon si nombre_personnes_à_charge = 5 alors 388,92 €
+        sinon
+          388,92€
+          + 33,72€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4822,41 +4822,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 260,29 €
-              -- Couple : 319,08 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 346,43 €
-          sinon si nombre_personnes_à_charge = 2 alors 357,39 €
-          sinon si nombre_personnes_à_charge = 3 alors 369,70 €
-          sinon si nombre_personnes_à_charge = 4 alors 381,85 €
-          sinon si nombre_personnes_à_charge = 5 alors 408,88 €
-          sinon
-            408,88 €
-            + 35,55€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 244,17 €
-                -- Couple : 296,16€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 322,89 €
-            sinon si nombre_personnes_à_charge = 2 alors 336,23 €
-            sinon si nombre_personnes_à_charge = 3 alors 349,77 €
-            sinon si nombre_personnes_à_charge = 4 alors 363,11 €
-            sinon si nombre_personnes_à_charge = 5 alors 390,16 €
-            sinon
-              390,16€
-              + 33,83€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 260,29 €
+            -- Couple : 319,08 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 346,43 €
+        sinon si nombre_personnes_à_charge = 2 alors 357,39 €
+        sinon si nombre_personnes_à_charge = 3 alors 369,70 €
+        sinon si nombre_personnes_à_charge = 4 alors 381,85 €
+        sinon si nombre_personnes_à_charge = 5 alors 408,88 €
+        sinon
+          408,88 €
+          + 35,55€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 244,17 €
+            -- Couple : 296,16€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 322,89 €
+        sinon si nombre_personnes_à_charge = 2 alors 336,23 €
+        sinon si nombre_personnes_à_charge = 3 alors 349,77 €
+        sinon si nombre_personnes_à_charge = 4 alors 363,11 €
+        sinon si nombre_personnes_à_charge = 5 alors 390,16 €
+        sinon
+          390,16€
+          + 33,83€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4883,41 +4883,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 263,15 €
-              -- Couple : 322,59 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 349,23 €
-          sinon si nombre_personnes_à_charge = 2 alors 361,32 €
-          sinon si nombre_personnes_à_charge = 3 alors 373,73 €
-          sinon si nombre_personnes_à_charge = 4 alors 386,05 €
-          sinon si nombre_personnes_à_charge = 5 alors 413,38 €
-          sinon
-            413,38 €
-            + 35,94€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 246,86 €
-                -- Couple : 299,42€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 326,44 €
-            sinon si nombre_personnes_à_charge = 2 alors 339,93 €
-            sinon si nombre_personnes_à_charge = 3 alors 353,62 €
-            sinon si nombre_personnes_à_charge = 4 alors 367,10 €
-            sinon si nombre_personnes_à_charge = 5 alors 394,45 €
-            sinon
-              394,45€
-              + 34,20€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 263,15 €
+            -- Couple : 322,59 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 349,23 €
+        sinon si nombre_personnes_à_charge = 2 alors 361,32 €
+        sinon si nombre_personnes_à_charge = 3 alors 373,73 €
+        sinon si nombre_personnes_à_charge = 4 alors 386,05 €
+        sinon si nombre_personnes_à_charge = 5 alors 413,38 €
+        sinon
+          413,38 €
+          + 35,94€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 246,86 €
+            -- Couple : 299,42€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 326,44 €
+        sinon si nombre_personnes_à_charge = 2 alors 339,93 €
+        sinon si nombre_personnes_à_charge = 3 alors 353,62 €
+        sinon si nombre_personnes_à_charge = 4 alors 367,10 €
+        sinon si nombre_personnes_à_charge = 5 alors 394,45 €
+        sinon
+          394,45€
+          + 34,20€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -4944,41 +4944,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 265,78 €
-              -- Couple : 325,82 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 352,72 €
-          sinon si nombre_personnes_à_charge = 2 alors 364,93 €
-          sinon si nombre_personnes_à_charge = 3 alors 377,51 €
-          sinon si nombre_personnes_à_charge = 4 alors 389,91 €
-          sinon si nombre_personnes_à_charge = 5 alors 417,51 €
-          sinon
-            417,51 €
-            + 36,30€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 249,33 €
-                -- Couple : 302,41€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 329,70 €
-            sinon si nombre_personnes_à_charge = 2 alors 343,33 €
-            sinon si nombre_personnes_à_charge = 3 alors 357,16 €
-            sinon si nombre_personnes_à_charge = 4 alors 370,77 €
-            sinon si nombre_personnes_à_charge = 5 alors 398,39 €
-            sinon
-              398,39€
-              + 34,54€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 265,78 €
+            -- Couple : 325,82 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 352,72 €
+        sinon si nombre_personnes_à_charge = 2 alors 364,93 €
+        sinon si nombre_personnes_à_charge = 3 alors 377,51 €
+        sinon si nombre_personnes_à_charge = 4 alors 389,91 €
+        sinon si nombre_personnes_à_charge = 5 alors 417,51 €
+        sinon
+          417,51 €
+          + 36,30€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 249,33 €
+            -- Couple : 302,41€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 329,70 €
+        sinon si nombre_personnes_à_charge = 2 alors 343,33 €
+        sinon si nombre_personnes_à_charge = 3 alors 357,16 €
+        sinon si nombre_personnes_à_charge = 4 alors 370,77 €
+        sinon si nombre_personnes_à_charge = 5 alors 398,39 €
+        sinon
+          398,39€
+          + 34,54€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -5005,41 +5005,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 271,49 €
-              -- Couple : 332,83 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 360,30 €
-          sinon si nombre_personnes_à_charge = 2 alors 372,78 €
-          sinon si nombre_personnes_à_charge = 3 alors 385,63 €
-          sinon si nombre_personnes_à_charge = 4 alors 398,29 €
-          sinon si nombre_personnes_à_charge = 5 alors 426,49 €
-          sinon
-            426,59 €
-            + 37,08€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 254,69 €
-                -- Couple : 308,91€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 336,79 €
-            sinon si nombre_personnes_à_charge = 2 alors 350,71 €
-            sinon si nombre_personnes_à_charge = 3 alors 364,84 €
-            sinon si nombre_personnes_à_charge = 4 alors 378,74 €
-            sinon si nombre_personnes_à_charge = 5 alors 406,96 €
-            sinon
-              406,96€
-              + 35,28€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 271,49 €
+            -- Couple : 332,83 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 360,30 €
+        sinon si nombre_personnes_à_charge = 2 alors 372,78 €
+        sinon si nombre_personnes_à_charge = 3 alors 385,63 €
+        sinon si nombre_personnes_à_charge = 4 alors 398,29 €
+        sinon si nombre_personnes_à_charge = 5 alors 426,49 €
+        sinon
+          426,59 €
+          + 37,08€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 254,69 €
+            -- Couple : 308,91€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 336,79 €
+        sinon si nombre_personnes_à_charge = 2 alors 350,71 €
+        sinon si nombre_personnes_à_charge = 3 alors 364,84 €
+        sinon si nombre_personnes_à_charge = 4 alors 378,74 €
+        sinon si nombre_personnes_à_charge = 5 alors 406,96 €
+        sinon
+          406,96€
+          + 35,28€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -5066,41 +5066,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 273,04 €
-              -- Couple : 334,73 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 362,35 €
-          sinon si nombre_personnes_à_charge = 2 alors 374,90 €
-          sinon si nombre_personnes_à_charge = 3 alors 387,83 €
-          sinon si nombre_personnes_à_charge = 4 alors 400,56 €
-          sinon si nombre_personnes_à_charge = 5 alors 428,92 €
-          sinon
-            428,92 €
-            + 37,29€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 256,14 €
-                -- Couple : 310,67€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 338,71 €
-            sinon si nombre_personnes_à_charge = 2 alors 352,71 €
-            sinon si nombre_personnes_à_charge = 3 alors 366,92 €
-            sinon si nombre_personnes_à_charge = 4 alors 380,90 €
-            sinon si nombre_personnes_à_charge = 5 alors 409,28 €
-            sinon
-              409,28€
-              + 35,48€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 273,04 €
+            -- Couple : 334,73 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 362,35 €
+        sinon si nombre_personnes_à_charge = 2 alors 374,90 €
+        sinon si nombre_personnes_à_charge = 3 alors 387,83 €
+        sinon si nombre_personnes_à_charge = 4 alors 400,56 €
+        sinon si nombre_personnes_à_charge = 5 alors 428,92 €
+        sinon
+          428,92 €
+          + 37,29€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 256,14 €
+            -- Couple : 310,67€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 338,71 €
+        sinon si nombre_personnes_à_charge = 2 alors 352,71 €
+        sinon si nombre_personnes_à_charge = 3 alors 366,92 €
+        sinon si nombre_personnes_à_charge = 4 alors 380,90 €
+        sinon si nombre_personnes_à_charge = 5 alors 409,28 €
+        sinon
+          409,28€
+          + 35,48€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -5127,41 +5127,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 273,26 €
-              -- Couple : 335 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 362,64 €
-          sinon si nombre_personnes_à_charge = 2 alors 375,20 €
-          sinon si nombre_personnes_à_charge = 3 alors 388,14 €
-          sinon si nombre_personnes_à_charge = 4 alors 400,88 €
-          sinon si nombre_personnes_à_charge = 5 alors 429,26 €
-          sinon
-            429,26 €
-            + 37,32€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 256,34 €
-                -- Couple : 310,92€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 338,98 €
-            sinon si nombre_personnes_à_charge = 2 alors 352,99 €
-            sinon si nombre_personnes_à_charge = 3 alors 367,21 €
-            sinon si nombre_personnes_à_charge = 4 alors 381,20 €
-            sinon si nombre_personnes_à_charge = 5 alors 409,61 €
-            sinon
-              409,61€
-              + 35,51€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 273,26 €
+            -- Couple : 335 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 362,64 €
+        sinon si nombre_personnes_à_charge = 2 alors 375,20 €
+        sinon si nombre_personnes_à_charge = 3 alors 388,14 €
+        sinon si nombre_personnes_à_charge = 4 alors 400,88 €
+        sinon si nombre_personnes_à_charge = 5 alors 429,26 €
+        sinon
+          429,26 €
+          + 37,32€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 256,34 €
+            -- Couple : 310,92€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 338,98 €
+        sinon si nombre_personnes_à_charge = 2 alors 352,99 €
+        sinon si nombre_personnes_à_charge = 3 alors 367,21 €
+        sinon si nombre_personnes_à_charge = 4 alors 381,20 €
+        sinon si nombre_personnes_à_charge = 5 alors 409,61 €
+        sinon
+          409,61€
+          + 35,51€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -5188,41 +5188,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 275,31 €
-              -- Couple : 337,51 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 365,36 €
-          sinon si nombre_personnes_à_charge = 2 alors 378,01 €
-          sinon si nombre_personnes_à_charge = 3 alors 391,05 €
-          sinon si nombre_personnes_à_charge = 4 alors 403,89 €
-          sinon si nombre_personnes_à_charge = 5 alors 432,48 €
-          sinon
-            432,48 €
-            + 37,60€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 258,26 €
-                -- Couple : 313,25€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 341,52 €
-            sinon si nombre_personnes_à_charge = 2 alors 355,64 €
-            sinon si nombre_personnes_à_charge = 3 alors 369,96 €
-            sinon si nombre_personnes_à_charge = 4 alors 384,06 €
-            sinon si nombre_personnes_à_charge = 5 alors 412,68 €
-            sinon
-              412,68€
-              + 35,78€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 275,31 €
+            -- Couple : 337,51 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 365,36 €
+        sinon si nombre_personnes_à_charge = 2 alors 378,01 €
+        sinon si nombre_personnes_à_charge = 3 alors 391,05 €
+        sinon si nombre_personnes_à_charge = 4 alors 403,89 €
+        sinon si nombre_personnes_à_charge = 5 alors 432,48 €
+        sinon
+          432,48 €
+          + 37,60€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 258,26 €
+            -- Couple : 313,25€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 341,52 €
+        sinon si nombre_personnes_à_charge = 2 alors 355,64 €
+        sinon si nombre_personnes_à_charge = 3 alors 369,96 €
+        sinon si nombre_personnes_à_charge = 4 alors 384,06 €
+        sinon si nombre_personnes_à_charge = 5 alors 412,68 €
+        sinon
+          412,68€
+          + 35,78€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
@@ -5249,41 +5249,41 @@ champ d'application CalculAllocationLogementAccessionPropriété
           * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 276,14 €
-              -- Couple : 338,53 €
-            )
-          sinon si nombre_personnes_à_charge = 1 alors 366,46 €
-          sinon si nombre_personnes_à_charge = 2 alors 379,15 €
-          sinon si nombre_personnes_à_charge = 3 alors 392,22 €
-          sinon si nombre_personnes_à_charge = 4 alors 405,10 €
-          sinon si nombre_personnes_à_charge = 5 alors 433,78 €
-          sinon
-            433,78 €
-            + 37,71€
-            * (décimal de (nombre_personnes_à_charge - 5))
-        )
-    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
           (
-            si nombre_personnes_à_charge = 0 alors
-              (
-                selon situation_familiale_calcul_apl sous forme
-                -- PersonneSeule : 259,04 €
-                -- Couple : 314,19€
-              )
-            sinon si nombre_personnes_à_charge = 1 alors 342,55 €
-            sinon si nombre_personnes_à_charge = 2 alors 356,70 €
-            sinon si nombre_personnes_à_charge = 3 alors 371,07 €
-            sinon si nombre_personnes_à_charge = 4 alors 385,21 €
-            sinon si nombre_personnes_à_charge = 5 alors 413,92 €
-            sinon
-              413,92€
-              + 35,88€
-              * (décimal de (nombre_personnes_à_charge - 5))
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 276,14 €
+            -- Couple : 338,53 €
           )
+        sinon si nombre_personnes_à_charge = 1 alors 366,46 €
+        sinon si nombre_personnes_à_charge = 2 alors 379,15 €
+        sinon si nombre_personnes_à_charge = 3 alors 392,22 €
+        sinon si nombre_personnes_à_charge = 4 alors 405,10 €
+        sinon si nombre_personnes_à_charge = 5 alors 433,78 €
+        sinon
+          433,78 €
+          + 37,71€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 259,04 €
+            -- Couple : 314,19€
+          )
+        sinon si nombre_personnes_à_charge = 1 alors 342,55 €
+        sinon si nombre_personnes_à_charge = 2 alors 356,70 €
+        sinon si nombre_personnes_à_charge = 3 alors 371,07 €
+        sinon si nombre_personnes_à_charge = 4 alors 385,21 €
+        sinon si nombre_personnes_à_charge = 5 alors 413,92 €
+        sinon
+          413,92€
+          + 35,88€
+          * (décimal de (nombre_personnes_à_charge - 5))
+      )
 
   # Une exception est à venir avec l'article 37
   définition calcul_plafond_mensualité_d842_6

--- a/tests/fr/code_construction_legislatif.catala_fr.result
+++ b/tests/fr/code_construction_legislatif.catala_fr.result
@@ -130,7 +130,7 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     selon demandeur.nationalité sous forme
     -- Française : vrai
     -- Étrangère de conditions :
-        conditions.satisfait_conditions_l512_2_code_sécurité_sociale
+      conditions.satisfait_conditions_l512_2_code_sécurité_sociale
 ```
 
 II.-Parmi les personnes mentionnées au I, peuvent bénéficier d'une aide
@@ -149,7 +149,7 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     -- Locataire : vrai
     -- RésidentLogementFoyer : vrai
     -- AccessionPropriétéLocalUsageExclusifHabitation :
-          ménage.logement.résidence_principale
+      ménage.logement.résidence_principale
     -- SousLocataire : vrai
     -- LocationAccession : vrai
   # Justifié par L831-2, avec une
@@ -236,14 +236,14 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     selon ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme
     -- LouéOuSousLouéÀDesTiers.Non : vrai
     -- LouéOuSousLouéÀDesTiers.Oui de personne :
-        (
-          résultat de France.VérificationÂgeSupérieurÀ avec {
-            -- date_naissance: personne.date_naissance_personne_sous_location
-            -- date_courante: date_courante
-            -- années: 30 an
-          }
-        ).est_supérieur
-        ou personne.conforme_article_l442_1
+      (
+        résultat de France.VérificationÂgeSupérieurÀ avec {
+          -- date_naissance: personne.date_naissance_personne_sous_location
+          -- date_courante: date_courante
+          -- années: 30 an
+        }
+      ).est_supérieur
+      ou personne.conforme_article_l442_1
   conséquence rempli
 ```
 
@@ -687,7 +687,7 @@ champ d'application ÉligibilitéAidePersonnaliséeLogement:
           convention.
             conventionné_livre_III_titre_V_chap_III
         -- BailleurPrivéAvecConventionnementSocial de convention :
-            convention.conventionné_livre_III_titre_II_chap_I_sec_3
+          convention.conventionné_livre_III_titre_II_chap_I_sec_3
         -- n'importe quel : faux
       )
     -- n'importe quel : faux
@@ -766,7 +766,7 @@ champ d'application ÉligibilitéAidePersonnaliséeLogement:
     -- LocationAccession de propriété :
       propriété.prêt.date_signature >= |2017-12-31|
     -- AccessionPropriétéLocalUsageExclusifHabitation de propriété :
-        propriété.prêt.date_signature >= |2017-12-31|
+      propriété.prêt.date_signature >= |2017-12-31|
     -- n'importe quel : faux
   conséquence non rempli
 ```
@@ -791,10 +791,10 @@ champ d'application ÉligibilitéAidePersonnaliséeLogement:
       et propriété.ancienneté_logement sous forme Ancien
       et logement_situé_commune_déséquilibre_l831_2
     -- AccessionPropriétéLocalUsageExclusifHabitation de propriété :
-        propriété.prêt.date_signature >= |2018-01-01|
-        et propriété.prêt.date_signature < |2020-01-01|
-        et propriété.ancienneté_logement sous forme Ancien
-        et logement_situé_commune_déséquilibre_l831_2
+      propriété.prêt.date_signature >= |2018-01-01|
+      et propriété.prêt.date_signature < |2020-01-01|
+      et propriété.ancienneté_logement sous forme Ancien
+      et logement_situé_commune_déséquilibre_l831_2
     -- n'importe quel : faux
   conséquence rempli
 ```
@@ -941,15 +941,15 @@ champ d'application ÉligibilitéAllocationLogement:
             selon personne_à_charge sous forme
             -- AutrePersonneÀCharge : faux
             -- EnfantÀCharge de enfant :
-                prestations_familiales.droit_ouvert de
-                  Prestations_familiales.EnfantPrestationsFamiliales {
-                    -- identifiant: enfant.identifiant
-                    -- obligation_scolaire: enfant.obligation_scolaire
-                    -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
-                    -- date_de_naissance: enfant.date_de_naissance
-                    -- a_déjà_ouvert_droit_aux_allocations_familiales:
-                      enfant.a_déjà_ouvert_droit_aux_allocations_familiales
-                  }
+              prestations_familiales.droit_ouvert de
+                Prestations_familiales.EnfantPrestationsFamiliales {
+                  -- identifiant: enfant.identifiant
+                  -- obligation_scolaire: enfant.obligation_scolaire
+                  -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
+                  -- date_de_naissance: enfant.date_de_naissance
+                  -- a_déjà_ouvert_droit_aux_allocations_familiales:
+                    enfant.a_déjà_ouvert_droit_aux_allocations_familiales
+                }
           )
       )
     = 1
@@ -969,17 +969,17 @@ champ d'application ÉligibilitéAllocationLogement:
             selon personne_à_charge sous forme
             -- AutrePersonneÀCharge : faux
             -- EnfantÀCharge de enfant :
-                non (
-                  prestations_familiales.droit_ouvert de
-                    Prestations_familiales.EnfantPrestationsFamiliales {
-                      -- identifiant: enfant.identifiant
-                      -- obligation_scolaire: enfant.obligation_scolaire
-                      -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
-                      -- date_de_naissance: enfant.date_de_naissance
-                      -- a_déjà_ouvert_droit_aux_allocations_familiales:
-                        enfant.a_déjà_ouvert_droit_aux_allocations_familiales
-                    }
-                )
+              non (
+                prestations_familiales.droit_ouvert de
+                  Prestations_familiales.EnfantPrestationsFamiliales {
+                    -- identifiant: enfant.identifiant
+                    -- obligation_scolaire: enfant.obligation_scolaire
+                    -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
+                    -- date_de_naissance: enfant.date_de_naissance
+                    -- a_déjà_ouvert_droit_aux_allocations_familiales:
+                      enfant.a_déjà_ouvert_droit_aux_allocations_familiales
+                  }
+              )
           )
       )
     = 0
@@ -1121,9 +1121,9 @@ champ d'application CalculetteAidesAuLogement:
         # Valeur par défaut, ne sera pas utilisée
         TypeAidesPersonnelleLogement.AllocationLogementSociale
       -- TypeÉligibilitéAllocationLogement.AllocationLogementFamiliale :
-          TypeAidesPersonnelleLogement.AllocationLogementFamiliale
+        TypeAidesPersonnelleLogement.AllocationLogementFamiliale
       -- TypeÉligibilitéAllocationLogement.AllocationLogementSociale :
-            TypeAidesPersonnelleLogement.AllocationLogementSociale
+        TypeAidesPersonnelleLogement.AllocationLogementSociale
     )
 
   définition aide_finale_formule égal à
@@ -1359,7 +1359,7 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     selon demandeur.nationalité sous forme
     -- Française : faux
     -- Étrangère de conditions :
-        conditions.satisfait_art_4_ordonnance_2002_mayotte
+      conditions.satisfait_art_4_ordonnance_2002_mayotte
 ```
 
 2° A l'article L. 822-5 , les mots : " prévue à l'article L. 821-1 du code de
@@ -1522,15 +1522,15 @@ champ d'application ÉligibilitéAllocationLogement
             selon personne_à_charge sous forme
             -- AutrePersonneÀCharge : faux
             -- EnfantÀCharge de enfant :
-                prestations_familiales.droit_ouvert de
-                  Prestations_familiales.EnfantPrestationsFamiliales {
-                    -- identifiant: enfant.identifiant
-                    -- obligation_scolaire: enfant.obligation_scolaire
-                    -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
-                    -- date_de_naissance: enfant.date_de_naissance
-                    -- a_déjà_ouvert_droit_aux_allocations_familiales:
-                      enfant.a_déjà_ouvert_droit_aux_allocations_familiales
-                  }
+              prestations_familiales.droit_ouvert de
+                Prestations_familiales.EnfantPrestationsFamiliales {
+                  -- identifiant: enfant.identifiant
+                  -- obligation_scolaire: enfant.obligation_scolaire
+                  -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
+                  -- date_de_naissance: enfant.date_de_naissance
+                  -- a_déjà_ouvert_droit_aux_allocations_familiales:
+                    enfant.a_déjà_ouvert_droit_aux_allocations_familiales
+                }
           )
       )
     >= 1
@@ -1832,15 +1832,15 @@ champ d'application ÉligibilitéAllocationLogement
             selon personne_à_charge sous forme
             -- AutrePersonneÀCharge : faux
             -- EnfantÀCharge de enfant :
-                prestations_familiales.droit_ouvert de
-                  Prestations_familiales.EnfantPrestationsFamiliales {
-                    -- identifiant: enfant.identifiant
-                    -- obligation_scolaire: enfant.obligation_scolaire
-                    -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
-                    -- date_de_naissance: enfant.date_de_naissance
-                    -- a_déjà_ouvert_droit_aux_allocations_familiales:
-                      enfant.a_déjà_ouvert_droit_aux_allocations_familiales
-                  }
+              prestations_familiales.droit_ouvert de
+                Prestations_familiales.EnfantPrestationsFamiliales {
+                  -- identifiant: enfant.identifiant
+                  -- obligation_scolaire: enfant.obligation_scolaire
+                  -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
+                  -- date_de_naissance: enfant.date_de_naissance
+                  -- a_déjà_ouvert_droit_aux_allocations_familiales:
+                    enfant.a_déjà_ouvert_droit_aux_allocations_familiales
+                }
           )
       )
     >= 1

--- a/tests/fr/code_construction_legislatif.catala_fr.result
+++ b/tests/fr/code_construction_legislatif.catala_fr.result
@@ -1096,7 +1096,8 @@ champ d'application CalculetteAidesAuLogement:
   # indépendamment de ce fait.
   définition
     éligibilité_allocation_logement.bénéficie_aide_personnalisée_logement
-  égal à faux
+  égal à
+    faux
 
   # Nous mettons ici la logique de notre interprétation de l'article L841-2
   # qui prend le maximum des deux types d'aide.

--- a/tests/fr/code_construction_reglementaire.catala_fr.result
+++ b/tests/fr/code_construction_reglementaire.catala_fr.result
@@ -3549,7 +3549,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
   définition calcul_équivalence_loyer_minimale.condition_2_du_832_25 égal à faux
   définition
     calcul_équivalence_loyer_minimale.ressources_ménage_arrondies
-  égal à ressources_ménage_arrondies
+  égal à
+    ressources_ménage_arrondies
   définition calcul_équivalence_loyer_minimale.n_nombre_parts_d832_25 égal à
     n_nombre_parts_d832_11
 ```
@@ -3848,7 +3849,8 @@ champ d'application CalculAidePersonnaliséeLogementFoyer:
     condition_2_du_832_25
   définition
     calcul_équivalence_loyer_minimale.ressources_ménage_arrondies
-  égal à ressources_ménage_arrondies
+  égal à
+    ressources_ménage_arrondies
   définition calcul_équivalence_loyer_minimale.n_nombre_parts_d832_25 égal à
     n_nombre_parts_d832_25
 ```
@@ -4619,7 +4621,8 @@ champ d'application CalculAllocationLogementAccessionPropriété:
   définition calcul_équivalence_loyer_minimale.condition_2_du_832_25 égal à vrai
   définition
     calcul_équivalence_loyer_minimale.ressources_ménage_arrondies
-  égal à ressources_ménage_arrondies
+  égal à
+    ressources_ménage_arrondies
   définition calcul_équivalence_loyer_minimale.n_nombre_parts_d832_25 égal à
     calcul_nombre_parts.n_nombre_parts_d832_11
   définition calcul_nombre_parts.nombre_personnes_à_charge égal à
@@ -5031,7 +5034,8 @@ champ d'application CalculAllocationLogementFoyer:
   définition calcul_équivalence_loyer_minimale.condition_2_du_832_25 égal à vrai
   définition
     calcul_équivalence_loyer_minimale.ressources_ménage_arrondies
-  égal à ressources_ménage_arrondies
+  égal à
+    ressources_ménage_arrondies
 
   définition calcul_nombre_parts.nombre_personnes_à_charge égal à
     nombre_personnes_à_charge

--- a/tests/fr/code_construction_reglementaire.catala_fr.result
+++ b/tests/fr/code_construction_reglementaire.catala_fr.result
@@ -1184,37 +1184,37 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     et selon personne_à_charge sous forme
     -- EnfantÀCharge de enfant : faux
     -- AutrePersonneÀCharge de parent :
-        parent.parenté = Ascendant
-        et parent.ressources
-        <= plafond_individuel_l815_9_sécu * 1,25
-        et (
-          # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
-          # à détecter
-          (
-            parent.date_naissance
-            + âge_l351_8_1_sécu
-            <= date_courante
-            ou (
-              parent.titulaire_allocation_personne_âgée
-              et (
-                résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
-                  -- date_naissance: parent.date_naissance
-                  -- date_courante: date_courante
-                  -- années: 65 an
-                }
-              ).est_inférieur_ou_égal
-            )
-          )
-          ou
-          # VERIF: parent.date_naissance + âge_l351_1_5_sécu est ambiguë,
-          # à détecter
-          (
-            parent.date_naissance
-            + âge_l351_1_5_sécu
-            <= date_courante
-            et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
+      parent.parenté = Ascendant
+      et parent.ressources
+      <= plafond_individuel_l815_9_sécu * 1,25
+      et (
+        # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
+        # à détecter
+        (
+          parent.date_naissance
+          + âge_l351_8_1_sécu
+          <= date_courante
+          ou (
+            parent.titulaire_allocation_personne_âgée
+            et (
+              résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
+                -- date_naissance: parent.date_naissance
+                -- date_courante: date_courante
+                -- années: 65 an
+              }
+            ).est_inférieur_ou_égal
           )
         )
+        ou
+        # VERIF: parent.date_naissance + âge_l351_1_5_sécu est ambiguë,
+        # à détecter
+        (
+          parent.date_naissance
+          + âge_l351_1_5_sécu
+          <= date_courante
+          et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
+        )
+      )
   conséquence rempli
 
   étiquette r823_4_2
@@ -1248,14 +1248,14 @@ champ d'application ÉligibilitéAidesPersonnelleLogement
     selon personne_à_charge sous forme
     -- EnfantÀCharge de enfant : faux
     -- AutrePersonneÀCharge de parent :
-        (
-          parent.parenté sous forme Ascendant
-          ou parent.parenté sous forme Descendant
-          ou parent.parenté sous forme CollatéralDeuxièmeTroisièmeDegré
-        )
-        et parent.incapacité_80_pourcent_ou_restriction_emploi
-        et parent.ressources
-        <= plafond_individuel_l815_9_sécu * 1,25
+      (
+        parent.parenté sous forme Ascendant
+        ou parent.parenté sous forme Descendant
+        ou parent.parenté sous forme CollatéralDeuxièmeTroisièmeDegré
+      )
+      et parent.incapacité_80_pourcent_ou_restriction_emploi
+      et parent.ressources
+      <= plafond_individuel_l815_9_sécu * 1,25
   conséquence rempli
 ```
 
@@ -1442,11 +1442,11 @@ champ d'application CalculAllocationLogement:
     -- Locataire de location : Location contenu location
     -- SousLocataire de location : Location contenu location
     -- RésidentLogementFoyer de logementfoyer :
-          CatégorieCalculAPL.LogementFoyer contenu logementfoyer
+      CatégorieCalculAPL.LogementFoyer contenu logementfoyer
     -- AccessionPropriétéLocalUsageExclusifHabitation de propriétaire :
-            AccessionPropriété contenu propriétaire
+      AccessionPropriété contenu propriétaire
     -- LocationAccession de propriétaire :
-              AccessionPropriété contenu propriétaire
+      AccessionPropriété contenu propriétaire
 
   définition aide_finale_formule égal à
     sous_calcul_traitement.aide_finale_formule
@@ -1463,11 +1463,11 @@ champ d'application CalculAidePersonnaliséeLogement:
     -- Locataire de location : Location contenu location
     -- SousLocataire de location : Location contenu location
     -- RésidentLogementFoyer de logementfoyer :
-          CatégorieCalculAPL.LogementFoyer contenu logementfoyer
+      CatégorieCalculAPL.LogementFoyer contenu logementfoyer
     -- AccessionPropriétéLocalUsageExclusifHabitation de propriétaire :
-            AccessionPropriété contenu propriétaire
+      AccessionPropriété contenu propriétaire
     -- LocationAccession de propriétaire :
-              AccessionPropriété contenu propriétaire
+      AccessionPropriété contenu propriétaire
 
   définition aide_finale_formule égal à
     sous_calcul_traitement.aide_finale_formule
@@ -1524,62 +1524,62 @@ champ d'application CalculAidePersonnaliséeLogement:
         }
       )
     -- LogementFoyer de logement_foyer_ :
-        (
-          soit traitement_formule égal à
-            résultat de CalculAidePersonnaliséeLogementFoyer avec {
-              -- ressources_ménage_arrondies: ressources_ménage
-              -- nombre_personnes_à_charge: nombre_personnes_à_charge
-              -- logement_foyer_jeunes_travailleurs:
-                logement_foyer_.logement_foyer_jeunes_travailleurs
-              -- zone: zone
-              -- résidence: résidence
-              -- date_courante: date_courante
-              -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
-              -- redevance: logement_foyer_.redevance
-              -- type_logement_foyer: logement_foyer_.type
-              -- date_conventionnement: logement_foyer_.date_conventionnement
-            }
-          dans
-          Traitement_formule_aide_finale {
-            -- aide_finale_formule:
-              traitement_formule.
-                CalculAidePersonnaliséeLogementFoyer.aide_finale_formule
-            -- traitement_aide_finale:
-              traitement_formule.
-                CalculAidePersonnaliséeLogementFoyer.traitement_aide_finale
+      (
+        soit traitement_formule égal à
+          résultat de CalculAidePersonnaliséeLogementFoyer avec {
+            -- ressources_ménage_arrondies: ressources_ménage
+            -- nombre_personnes_à_charge: nombre_personnes_à_charge
+            -- logement_foyer_jeunes_travailleurs:
+              logement_foyer_.logement_foyer_jeunes_travailleurs
+            -- zone: zone
+            -- résidence: résidence
+            -- date_courante: date_courante
+            -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
+            -- redevance: logement_foyer_.redevance
+            -- type_logement_foyer: logement_foyer_.type
+            -- date_conventionnement: logement_foyer_.date_conventionnement
           }
-        )
+        dans
+        Traitement_formule_aide_finale {
+          -- aide_finale_formule:
+            traitement_formule.
+              CalculAidePersonnaliséeLogementFoyer.aide_finale_formule
+          -- traitement_aide_finale:
+            traitement_formule.
+              CalculAidePersonnaliséeLogementFoyer.traitement_aide_finale
+        }
+      )
     -- AccessionPropriété de propriétaire :
-          (
-            soit traitement_formule égal à
-              résultat de CalculAidePersonnaliséeLogementAccessionPropriété avec {
-                -- ressources_ménage_arrondies: ressources_ménage
-                -- nombre_personnes_à_charge: nombre_personnes_à_charge
-                -- zone: zone
-                -- date_courante: date_courante
-                -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
-                -- mensualité_principale: propriétaire.mensualité_principale
-                -- type_travaux_logement: propriétaire.type_travaux_logement_d832_15
-                -- date_signature_prêt: propriétaire.prêt.date_signature
-                -- local_habité_première_fois_bénéficiaire:
-                  propriétaire.local_habité_première_fois_bénéficiaire
-                -- date_entrée_logement: propriétaire.date_entrée_logement
-                -- copropriété: propriétaire.copropriété
-                -- situation_r822_11_13_17: propriétaire.situation_r822_11_13_17
-                -- type_prêt: propriétaire.prêt.type_prêt
-                -- ancienneté_logement: propriétaire.ancienneté_logement
-                -- résidence: résidence
-              }
-            dans
-            Traitement_formule_aide_finale {
-              -- aide_finale_formule:
-                traitement_formule.
-                  CalculAidePersonnaliséeLogementAccessionPropriété.aide_finale_formule
-              -- traitement_aide_finale:
-                traitement_formule.
-                  CalculAidePersonnaliséeLogementAccessionPropriété.traitement_aide_finale
-            }
-          )
+      (
+        soit traitement_formule égal à
+          résultat de CalculAidePersonnaliséeLogementAccessionPropriété avec {
+            -- ressources_ménage_arrondies: ressources_ménage
+            -- nombre_personnes_à_charge: nombre_personnes_à_charge
+            -- zone: zone
+            -- date_courante: date_courante
+            -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
+            -- mensualité_principale: propriétaire.mensualité_principale
+            -- type_travaux_logement: propriétaire.type_travaux_logement_d832_15
+            -- date_signature_prêt: propriétaire.prêt.date_signature
+            -- local_habité_première_fois_bénéficiaire:
+              propriétaire.local_habité_première_fois_bénéficiaire
+            -- date_entrée_logement: propriétaire.date_entrée_logement
+            -- copropriété: propriétaire.copropriété
+            -- situation_r822_11_13_17: propriétaire.situation_r822_11_13_17
+            -- type_prêt: propriétaire.prêt.type_prêt
+            -- ancienneté_logement: propriétaire.ancienneté_logement
+            -- résidence: résidence
+          }
+        dans
+        Traitement_formule_aide_finale {
+          -- aide_finale_formule:
+            traitement_formule.
+              CalculAidePersonnaliséeLogementAccessionPropriété.aide_finale_formule
+          -- traitement_aide_finale:
+            traitement_formule.
+              CalculAidePersonnaliséeLogementAccessionPropriété.traitement_aide_finale
+        }
+      )
 
 champ d'application CalculAllocationLogement:
   définition sous_calcul_traitement égal à
@@ -1622,65 +1622,65 @@ champ d'application CalculAllocationLogement:
         }
       )
     -- LogementFoyer de logement_foyer_ :
-        (
-          soit traitement_formule égal à
-            résultat de CalculAllocationLogementFoyer avec {
-              -- ressources_ménage_arrondies: ressources_ménage
-              -- nombre_personnes_à_charge: nombre_personnes_à_charge
-              -- résidence: résidence
-              -- zone: zone
-              -- date_courante: date_courante
-              -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
-              -- logement_foyer_jeunes_travailleurs:
-                logement_foyer_.logement_foyer_jeunes_travailleurs
-              -- redevance: logement_foyer_.redevance
-              -- catégorie_équivalence_loyer_d842_16:
-                logement_foyer_.catégorie_équivalence_loyer_d842_16
-              -- type_logement_foyer: logement_foyer_.type
-              -- date_conventionnement: logement_foyer_.date_conventionnement
-            }
-          dans
-          Traitement_formule_aide_finale {
-            -- aide_finale_formule:
-              traitement_formule.aide_finale_formule
-            -- traitement_aide_finale:
-              traitement_formule.
-                CalculAllocationLogementFoyer.traitement_aide_finale
+      (
+        soit traitement_formule égal à
+          résultat de CalculAllocationLogementFoyer avec {
+            -- ressources_ménage_arrondies: ressources_ménage
+            -- nombre_personnes_à_charge: nombre_personnes_à_charge
+            -- résidence: résidence
+            -- zone: zone
+            -- date_courante: date_courante
+            -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
+            -- logement_foyer_jeunes_travailleurs:
+              logement_foyer_.logement_foyer_jeunes_travailleurs
+            -- redevance: logement_foyer_.redevance
+            -- catégorie_équivalence_loyer_d842_16:
+              logement_foyer_.catégorie_équivalence_loyer_d842_16
+            -- type_logement_foyer: logement_foyer_.type
+            -- date_conventionnement: logement_foyer_.date_conventionnement
           }
-        )
+        dans
+        Traitement_formule_aide_finale {
+          -- aide_finale_formule:
+            traitement_formule.aide_finale_formule
+          -- traitement_aide_finale:
+            traitement_formule.
+              CalculAllocationLogementFoyer.traitement_aide_finale
+        }
+      )
     -- AccessionPropriété de propriétaire :
-          (
-            soit traitement_formule égal à
-              résultat de CalculAllocationLogementAccessionPropriété avec {
-                -- ressources_ménage_arrondies: ressources_ménage
-                -- nombre_personnes_à_charge: nombre_personnes_à_charge
-                -- zone: zone
-                -- résidence: résidence
-                -- opérations_logement_évolutifs_sociaux_accession_propriété_aidée_État:
-                  propriétaire.
-                    opérations_logement_évolutifs_sociaux_accession_propriété_aidée_État
-                -- date_courante: date_courante
-                -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
-                -- mensualité_principale: propriétaire.mensualité_principale
-                -- charges_mensuelles_prêt: propriétaire.charges_mensuelles_prêt
-                -- type_travaux_logement: propriétaire.type_travaux_logement_r842_5
-                -- date_signature_prêt: propriétaire.prêt.date_signature
-                -- local_habité_première_fois_bénéficiaire:
-                  propriétaire.local_habité_première_fois_bénéficiaire
-                -- date_entrée_logement: propriétaire.date_entrée_logement
-                -- copropriété: propriétaire.copropriété
-                -- situation_r822_11_13_17: propriétaire.situation_r822_11_13_17
-              }
-            dans
-            Traitement_formule_aide_finale {
-              -- aide_finale_formule:
-                traitement_formule.
-                  CalculAllocationLogementAccessionPropriété.aide_finale_formule
-              -- traitement_aide_finale:
-                traitement_formule.
-                  CalculAllocationLogementAccessionPropriété.traitement_aide_finale
-            }
-          )
+      (
+        soit traitement_formule égal à
+          résultat de CalculAllocationLogementAccessionPropriété avec {
+            -- ressources_ménage_arrondies: ressources_ménage
+            -- nombre_personnes_à_charge: nombre_personnes_à_charge
+            -- zone: zone
+            -- résidence: résidence
+            -- opérations_logement_évolutifs_sociaux_accession_propriété_aidée_État:
+              propriétaire.
+                opérations_logement_évolutifs_sociaux_accession_propriété_aidée_État
+            -- date_courante: date_courante
+            -- situation_familiale_calcul_apl: situation_familiale_calcul_apl
+            -- mensualité_principale: propriétaire.mensualité_principale
+            -- charges_mensuelles_prêt: propriétaire.charges_mensuelles_prêt
+            -- type_travaux_logement: propriétaire.type_travaux_logement_r842_5
+            -- date_signature_prêt: propriétaire.prêt.date_signature
+            -- local_habité_première_fois_bénéficiaire:
+              propriétaire.local_habité_première_fois_bénéficiaire
+            -- date_entrée_logement: propriétaire.date_entrée_logement
+            -- copropriété: propriétaire.copropriété
+            -- situation_r822_11_13_17: propriétaire.situation_r822_11_13_17
+          }
+        dans
+        Traitement_formule_aide_finale {
+          -- aide_finale_formule:
+            traitement_formule.
+              CalculAllocationLogementAccessionPropriété.aide_finale_formule
+          -- traitement_aide_finale:
+            traitement_formule.
+              CalculAllocationLogementAccessionPropriété.traitement_aide_finale
+        }
+      )
 ```
 
 ####### Sous-section 1 : Ouverture et extinction des droits
@@ -2124,15 +2124,15 @@ champ d'application ÉligibilitéPrimeDeDéménagement:
       selon informations.date_naissance_troisième_enfant_ou_dernier_si_plus sous forme
       -- MoinsDeTroisEnfants : faux
       -- PlusDeTroisEnfants de date_naissance_ou_grossesse :
-          (
-            selon date_naissance_ou_grossesse sous forme
-            -- AvantPremierJourMoisCivilTroisièmeMoisDeGrossesse : faux
-            -- AprèsPremierJourMoisCivilTroisièmeMoisDeGrossesse : vrai
-            -- DateDeNaissance de date_naissance :
-                  # VERIF: ambigü
-                  date_courante
-                  <= ((premier_jour_du_mois de (date_naissance + 2 an))) + (-1 jour)
-          )
+        (
+          selon date_naissance_ou_grossesse sous forme
+          -- AvantPremierJourMoisCivilTroisièmeMoisDeGrossesse : faux
+          -- AprèsPremierJourMoisCivilTroisièmeMoisDeGrossesse : vrai
+          -- DateDeNaissance de date_naissance :
+            # VERIF: ambigü
+            date_courante
+            <= ((premier_jour_du_mois de (date_naissance + 2 an))) + (-1 jour)
+        )
     )
   conséquence rempli
 
@@ -2332,9 +2332,9 @@ champ d'application ImpayéDépenseLogement
     selon dépense_logement_brute sous forme
     -- Loyer : 0€ # Ne devrait pas arriver
     -- Mensualité de mensualité_brute :
-        mensualité_brute * 2,0
+      mensualité_brute * 2,0
     -- TotalAnnuelÉchéances de échéance_prêt_brute :
-          échéance_prêt_brute * (1,0 / 6,0)
+      échéance_prêt_brute * (1,0 / 6,0)
 ```
 
 2° Lorsque l'aide personnelle au logement est versée directement auprès de
@@ -2359,7 +2359,7 @@ champ d'application ImpayéDépenseLogement
     -- Loyer : 0€ # ne devrait pas arriver
     -- Mensualité de mensualité_nette : mensualité_nette * 2,0
     -- TotalAnnuelÉchéances de échéance_prêt_nette :
-          échéance_prêt_nette * (1,0 / 6,0)
+      échéance_prêt_nette * (1,0 / 6,0)
 ```
 
 L'échéance de prêt brute correspond à celle figurant dans le contrat de prêt.
@@ -2380,9 +2380,9 @@ champ d'application ImpayéDépenseLogement
     selon dépense_logement sous forme
     -- Loyer de loyer : Loyer contenu loyer # ne devrait pas arriver
     -- Mensualité de mensualité :
-        Mensualité contenu (mensualité - montant_apl)
+      Mensualité contenu (mensualité - montant_apl)
     -- TotalAnnuelÉchéances de total_échéances :
-          TotalAnnuelÉchéances contenu (total_échéances - (montant_apl * 12,0))
+      TotalAnnuelÉchéances contenu (total_échéances - (montant_apl * 12,0))
 ```
 
 ####### Article R824-3 | LEGIARTI000038878873
@@ -4168,7 +4168,7 @@ champ d'application CalculÉquivalenceLoyerMinimale:
           selon tranche.haut sous forme
           -- LimiteTranche.Infini : LimiteTrancheDécimal.Infini
           -- LimiteTranche.Revenu de tranche_haut :
-              LimiteTrancheDécimal.Revenu contenu ((décimal de tranche_haut) * n_nombre_parts_d832_25)
+            LimiteTrancheDécimal.Revenu contenu ((décimal de tranche_haut) * n_nombre_parts_d832_25)
         )
       -- bas:
         décimal de tranche.bas
@@ -4201,8 +4201,8 @@ champ d'application CalculÉquivalenceLoyerMinimale:
                         * tranche.taux
                     )
                   -- LimiteTrancheDécimal.Infini :
-                      (ressources_ménage_arrondies - tranche.bas)
-                      * tranche.taux
+                    (ressources_ménage_arrondies - tranche.bas)
+                    * tranche.taux
               )
             )
               pour tranche parmi tranches_revenus_d832_26_multipliées
@@ -4252,8 +4252,8 @@ champ d'application CalculÉquivalenceLoyerMinimale:
                           * tranche.taux
                       )
                     -- LimiteTrancheDécimal.Infini :
-                        (ressources_ménage_arrondies - tranche.bas)
-                        * tranche.taux
+                      (ressources_ménage_arrondies - tranche.bas)
+                      * tranche.taux
                   )
               )
                 pour tranche parmi tranches_revenus_d832_26_multipliées
@@ -6779,15 +6779,15 @@ champ d'application CalculAllocationLogement
     # Les deux premiers cas ne se déclenchent pas dans cette exception donc
     # nous renvoyons des valeurs nulles qui ne seront jamais utilisées.
     -- AccessionPropriété :
-        Traitement_formule_aide_finale {
-          -- aide_finale_formule: 0€
-          -- traitement_aide_finale: traitement_nul_tout_le_temps
-        }
+      Traitement_formule_aide_finale {
+        -- aide_finale_formule: 0€
+        -- traitement_aide_finale: traitement_nul_tout_le_temps
+      }
     -- Location :
-          Traitement_formule_aide_finale {
-            -- aide_finale_formule: 0€
-            -- traitement_aide_finale: traitement_nul_tout_le_temps
-          }
+      Traitement_formule_aide_finale {
+        -- aide_finale_formule: 0€
+        -- traitement_aide_finale: traitement_nul_tout_le_temps
+      }
 
 déclaration traitement_nul_tout_le_temps contenu argent
 dépend de aide_finale contenu argent égal à 0€

--- a/tests/fr/tests_calcul_al_locatif.catala_fr.result
+++ b/tests/fr/tests_calcul_al_locatif.catala_fr.result
@@ -22,7 +22,8 @@ champ d'application Exemple1:
   définition calcul.résidence égal à Métropole
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.type_aide égal à
     AL.TypeAidesPersonnelleLogement.AllocationLogementFamiliale
   définition calcul.colocation égal à faux
@@ -54,7 +55,8 @@ champ d'application Exemple2:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.type_aide égal à
     AL.TypeAidesPersonnelleLogement.AllocationLogementFamiliale
   définition calcul.colocation égal à faux
@@ -82,7 +84,8 @@ champ d'application Exemple3:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.type_aide égal à
     AL.TypeAidesPersonnelleLogement.AllocationLogementFamiliale
   définition calcul.colocation égal à faux
@@ -112,7 +115,8 @@ champ d'application Exemple4:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.type_aide égal à
     AL.TypeAidesPersonnelleLogement.AllocationLogementFamiliale
   définition calcul.colocation égal à faux

--- a/tests/fr/tests_calcul_apl_locatif.catala_fr.result
+++ b/tests/fr/tests_calcul_apl_locatif.catala_fr.result
@@ -15,7 +15,8 @@ champ d'application Exemple1:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone1
   définition calcul.situation_familiale_calcul_apl égal à Couple
   définition calcul.nombre_personnes_à_charge égal à 3
@@ -53,7 +54,8 @@ champ d'application Exemple2:
   définition calcul.ressources_ménage_arrondies égal à 11500 €
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.bénéficiaire_aide_adulte_ou_enfant_handicapés égal à faux
   définition calcul.logement_meublé_d842_2 égal à faux
   définition calcul.résidence égal à Métropole
@@ -77,7 +79,8 @@ champ d'application Exemple3:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone3
   définition calcul.situation_familiale_calcul_apl égal à PersonneSeule
   définition calcul.nombre_personnes_à_charge égal à 3
@@ -108,7 +111,8 @@ champ d'application Exemple4:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone1
   définition calcul.situation_familiale_calcul_apl égal à Couple
   définition calcul.nombre_personnes_à_charge égal à 1
@@ -139,7 +143,8 @@ champ d'application Exemple5:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone1
   définition calcul.situation_familiale_calcul_apl égal à PersonneSeule
   définition calcul.nombre_personnes_à_charge égal à 0
@@ -170,7 +175,8 @@ champ d'application Exemple6:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone2
   définition calcul.situation_familiale_calcul_apl égal à Couple
   définition calcul.nombre_personnes_à_charge égal à 0
@@ -201,7 +207,8 @@ champ d'application Exemple7:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone2
   définition calcul.situation_familiale_calcul_apl égal à Couple
   définition calcul.nombre_personnes_à_charge égal à 6
@@ -232,7 +239,8 @@ champ d'application Exemple8:
   définition calcul.logement_est_chambre égal à vrai
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone1
   définition calcul.situation_familiale_calcul_apl égal à Couple
   définition calcul.nombre_personnes_à_charge égal à 0
@@ -265,7 +273,8 @@ champ d'application Exemple9:
   définition calcul.logement_est_chambre égal à faux
   définition
     calcul.âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
-  égal à faux
+  égal à
+    faux
   définition calcul.zone égal à Zone1
   définition calcul.situation_familiale_calcul_apl égal à PersonneSeule
   définition calcul.nombre_personnes_à_charge égal à 0

--- a/tests/fr/tp_3_corrige.catala_fr
+++ b/tests/fr/tp_3_corrige.catala_fr
@@ -1,0 +1,542 @@
+# T.P. N° 3 – Ordonnancement selon l'âge
+
+## Données en entrée:
+
+* Global: Mois de droit à calculer
+* Personne:
+  * Rôle : demandeur, conjoint du demandeur, enfant
+  * Date de naissance
+
+## Modélisation attendue en sortie
+
+* Global: Montant du MF familial
+* Personne:
+  * Taux de MFB appliqué
+  * Montant du MF individuel
+
+```catala
+déclaration énumération Rôle:
+  -- Demandeur
+  -- Conjoint
+  -- Enfant
+
+déclaration énumération RôleAvecRang:
+  -- Demandeur
+  -- Conjoint
+  # L'entier est le rang de l'enfant : 0 pour le plus
+  # âgé, etc.
+  -- Enfant contenu entier
+
+déclaration structure Personne:
+  donnée rôle contenu Rôle
+  donnée date_naissance contenu date
+  donnée identifiant contenu entier
+
+déclaration champ d'application CalculMontantForfaitairePersonne:
+  # Convention : la date en entrée est le premier jours du mois de droit à
+  # calculer
+  entrée mois_de_droit_à_calculer contenu date
+  entrée rôle contenu RôleAvecRang
+  entrée foyer_isolé contenu booléen
+
+  interne montant_forfaitaire_base contenu argent
+  résultat taux_montant_forfaitaire_base contenu décimal
+
+  résultat montant_forfaitaire contenu argent
+
+déclaration champ d'application CalculMontantForfaitaireGlobal:
+  entrée foyer_isolé contenu booléen
+  # On suppose que la liste est triée selon l'ordre croissant des dates
+  # de naissance des personnes.
+  entrée personnes contenu liste de Personne
+  # Convention : la date en entrée est le premier jours du mois de droit à
+  # calculer
+  entrée mois_de_droit_à_calculer contenu date
+  résultat rôles_avec_rang contenu liste de RôleAvecRang
+  résultat montants_forfaitaires_individuel contenu liste de CalculMontantForfaitairePersonne
+  résultat montant_forfaitaire_total contenu argent
+```
+
+##  ToDo : Calculer, pour un mois de droit donné, le montant forfaitaire familial RSA
+
+Selon les règles suivantes :
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  étiquette base_zéro définition taux_montant_forfaitaire_base égal à 0%
+
+  définition montant_forfaitaire égal à
+    montant_forfaitaire_base * taux_montant_forfaitaire_base
+
+champ d'application CalculMontantForfaitaireGlobal:
+  définition montant_forfaitaire_total égal à
+    somme argent de montant_forfaitaire_individuel.montant_forfaitaire
+      pour montant_forfaitaire_individuel parmi montants_forfaitaires_individuel
+```
+
+MF = 100% x Montant forfaitaire de base (MFB) pour le demandeur
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle = RôleAvecRang.Demandeur
+  conséquence égal à 100%
+```
+
++ 50% x MFB pour le conjoint
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle = RôleAvecRang.Conjoint
+  conséquence égal à 50%
+```
+
++ 30% x MFB pour l'enfant le plus âgé
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle sous forme RôleAvecRang.Enfant de rang et rang = 0
+  conséquence égal à 30%
+```
+
++ 40% x MFB pour chaque enfant supplémentaire dans la limite de 3 enfants, en
+  considérant les enfants en ordre décroissant selon l'âge
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  étiquette enfants exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle sous forme RôleAvecRang.Enfant de rang et (rang > 0 et rang < 3)
+  conséquence égal à 40%
+```
+
+Pour un foyer isolé, le 1er enfant se voit attribuer la règle dévolue aux
+conjoint (50% x MFB) et les autres suivants suivent la même conséquence : 30%
+pour le 2ème enfant et 40% pour le 3ème
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception enfants
+  définition taux_montant_forfaitaire_base sous condition
+    rôle sous forme RôleAvecRang.Enfant et foyer_isolé
+  conséquence égal à
+    selon rôle sous forme
+    -- RôleAvecRang.Enfant de rang :
+      si rang = 0 alors 50%
+      sinon si rang = 1 alors 30%
+      sinon si rang = 2 alors 40%
+      sinon 0%
+    # Cas impossible : rôle est toujours Enfant dans cette exception.
+    -- n'importe quel : 0%
+```
+
+En cas de naissances multiples, tous
+les enfants jumeaux suivent la même règle : si les jumeaux sont précédés par 2
+autres enfants plus âgés, l'ensemble des jumeaux se voit attribuer le même
+pourcentage (la règle ne se limite donc pas à 3 enfants)
+
+```catala
+champ d'application CalculMontantForfaitaireGlobal:
+  définition rôles_avec_rang égal à
+    soit (résultat_rôles_avec_rang, date_naissance_dernier_enfant, rang_dernier_enfant_plus_un, nombre_jumeaux_même_date) égal à
+      combinaison de (rôles_avec_rang, date_de_naissance_enfant_précédent, rang_enfant, nombre_jumeaux_même_date)
+        initialement ( [], |1900-01-01|, (0), (1))
+        avec (
+          selon personne.rôle sous forme
+          -- Rôle.Demandeur :
+            (
+                  rôles_avec_rang
+                  ++ [ RôleAvecRang.Demandeur ],
+                  date_de_naissance_enfant_précédent,
+                  rang_enfant,
+                  nombre_jumeaux_même_date
+            )
+          -- Rôle.Conjoint :
+              (
+                    rôles_avec_rang
+                    ++ [ RôleAvecRang.Conjoint ],
+                    date_de_naissance_enfant_précédent,
+                    rang_enfant,
+                    nombre_jumeaux_même_date
+              )
+          -- Rôle.Enfant :
+                si personne.date_naissance = date_de_naissance_enfant_précédent alors
+                  (
+                        rôles_avec_rang
+                        ++ [ RôleAvecRang.Enfant contenu (rang_enfant - nombre_jumeaux_même_date) ],
+                        date_de_naissance_enfant_précédent, rang_enfant + 1 ,
+                        nombre_jumeaux_même_date + 1
+                  )
+                sinon
+                  (
+                      rôles_avec_rang
+                      ++ [ RôleAvecRang.Enfant contenu (rang_enfant) ],
+                      personne.date_naissance, (rang_enfant + 1),
+                      1
+                  )
+        )
+        pour personne parmi personnes
+    dans
+    résultat_rôles_avec_rang
+
+  définition montants_forfaitaires_individuel égal à
+    (
+      résultat de CalculMontantForfaitairePersonne avec {
+        -- mois_de_droit_à_calculer: mois_de_droit_à_calculer
+        -- foyer_isolé: foyer_isolé
+        -- rôle : rôle_avec_rang
+      }
+    )
+      pour (personne, rôle_avec_rang) parmi (personnes, rôles_avec_rang)
+```
+
+Barème
+
+à compter du Montant forfaitaire de base
+------------ --------------------------
+01-04-2019   559,74
+01-04-2020   564,78
+01-04-2021   565,34
+01-04-2022   566,42
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2019-04-01| et mois_de_droit_à_calculer < |2020-04-01|
+  conséquence égal à 559,74 €
+
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2020-04-01| et mois_de_droit_à_calculer < |2021-04-01|
+  conséquence égal à 564,78 €
+
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2021-04-01| et mois_de_droit_à_calculer < |2022-04-01|
+  conséquence égal à 565,34 €
+
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2022-04-01|
+  conséquence égal à 566,42 €
+```
+
+## Réaliser un whatif permettant de vérifier le bon fonctionnement du moteur
+
+Modéliser des cas avec:
+
+* 1 demandeur seul
+
+```catala
+déclaration champ d'application Test1:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test1:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes: [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ]
+    }
+```
+
+* 1 demandeur 1 conjoint
+
+```catala
+déclaration champ d'application Test2:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test2:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ]
+    }
+```
+
+* et varier ces 2 cas principaux avec respectivement
+* aucun enfant
+* 1 seul enfant
+
+```catala
+déclaration champ d'application Test3:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test3:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+
+déclaration champ d'application Test4:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test4:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+```
+* 2 enfants
+
+```catala
+déclaration champ d'application Test5:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test5:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ]
+    }
+
+déclaration champ d'application Test6:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test6:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ]
+    }
+```
+
+* 3 enfants
+
+```catala
+déclaration champ d'application Test7:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test7:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test8:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test8:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```
+
+* 5 enfants
+
+```catala
+déclaration champ d'application Test9:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test9:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2013-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2014-01-01| } ]
+    }
+
+déclaration champ d'application Test10:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test10:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2013-01-01| } ;
+          Personne { -- identifiant: 6 -- rôle: Rôle.Enfant -- date_naissance: |2014-01-01| } ]
+    }
+```
+
+* 2 enfants jumeaux
+
+```catala
+déclaration champ d'application Test11:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test11:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+
+déclaration champ d'application Test12:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test12:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+```
+
+* 4 enfants dont 2 jumeaux, les jumeaux étant les plus jeunes
+
+```catala
+déclaration champ d'application Test13:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test13:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test14:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test14:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```
+* 4 enfants dont 2 jumeaux, les jumeaux étant les plus âgés
+
+```catala
+déclaration champ d'application Test15:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test15:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test16:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test16:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```
+
+* 4 enfants dont 3 triplés, les jumeaux étant les plus jeunes
+
+```catala
+déclaration champ d'application Test17:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test17:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test18:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test18:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```

--- a/tests/fr/tp_3_corrige.catala_fr.result
+++ b/tests/fr/tp_3_corrige.catala_fr.result
@@ -1,0 +1,542 @@
+# T.P. N° 3 – Ordonnancement selon l'âge
+
+## Données en entrée:
+
+* Global: Mois de droit à calculer
+* Personne:
+  * Rôle : demandeur, conjoint du demandeur, enfant
+  * Date de naissance
+
+## Modélisation attendue en sortie
+
+* Global: Montant du MF familial
+* Personne:
+  * Taux de MFB appliqué
+  * Montant du MF individuel
+
+```catala
+déclaration énumération Rôle:
+  -- Demandeur
+  -- Conjoint
+  -- Enfant
+
+déclaration énumération RôleAvecRang:
+  -- Demandeur
+  -- Conjoint
+  # L'entier est le rang de l'enfant : 0 pour le plus
+  # âgé, etc.
+  -- Enfant contenu entier
+
+déclaration structure Personne:
+  donnée rôle contenu Rôle
+  donnée date_naissance contenu date
+  donnée identifiant contenu entier
+
+déclaration champ d'application CalculMontantForfaitairePersonne:
+  # Convention : la date en entrée est le premier jours du mois de droit à
+  # calculer
+  entrée mois_de_droit_à_calculer contenu date
+  entrée rôle contenu RôleAvecRang
+  entrée foyer_isolé contenu booléen
+
+  interne montant_forfaitaire_base contenu argent
+  résultat taux_montant_forfaitaire_base contenu décimal
+
+  résultat montant_forfaitaire contenu argent
+
+déclaration champ d'application CalculMontantForfaitaireGlobal:
+  entrée foyer_isolé contenu booléen
+  # On suppose que la liste est triée selon l'ordre croissant des dates
+  # de naissance des personnes.
+  entrée personnes contenu liste de Personne
+  # Convention : la date en entrée est le premier jours du mois de droit à
+  # calculer
+  entrée mois_de_droit_à_calculer contenu date
+  résultat rôles_avec_rang contenu liste de RôleAvecRang
+  résultat montants_forfaitaires_individuel contenu liste de CalculMontantForfaitairePersonne
+  résultat montant_forfaitaire_total contenu argent
+```
+
+##  ToDo : Calculer, pour un mois de droit donné, le montant forfaitaire familial RSA
+
+Selon les règles suivantes :
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  étiquette base_zéro définition taux_montant_forfaitaire_base égal à 0%
+
+  définition montant_forfaitaire égal à
+    montant_forfaitaire_base * taux_montant_forfaitaire_base
+
+champ d'application CalculMontantForfaitaireGlobal:
+  définition montant_forfaitaire_total égal à
+    somme argent de montant_forfaitaire_individuel.montant_forfaitaire
+      pour montant_forfaitaire_individuel parmi montants_forfaitaires_individuel
+```
+
+MF = 100% x Montant forfaitaire de base (MFB) pour le demandeur
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle = RôleAvecRang.Demandeur
+  conséquence égal à 100%
+```
+
++ 50% x MFB pour le conjoint
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle = RôleAvecRang.Conjoint
+  conséquence égal à 50%
+```
+
++ 30% x MFB pour l'enfant le plus âgé
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle sous forme RôleAvecRang.Enfant de rang et rang = 0
+  conséquence égal à 30%
+```
+
++ 40% x MFB pour chaque enfant supplémentaire dans la limite de 3 enfants, en
+  considérant les enfants en ordre décroissant selon l'âge
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  étiquette enfants exception base_zéro
+  définition taux_montant_forfaitaire_base sous condition
+    rôle sous forme RôleAvecRang.Enfant de rang et (rang > 0 et rang < 3)
+  conséquence égal à 40%
+```
+
+Pour un foyer isolé, le 1er enfant se voit attribuer la règle dévolue aux
+conjoint (50% x MFB) et les autres suivants suivent la même conséquence : 30%
+pour le 2ème enfant et 40% pour le 3ème
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  exception enfants
+  définition taux_montant_forfaitaire_base sous condition
+    rôle sous forme RôleAvecRang.Enfant et foyer_isolé
+  conséquence égal à
+    selon rôle sous forme
+    -- RôleAvecRang.Enfant de rang :
+      si rang = 0 alors 50%
+      sinon si rang = 1 alors 30%
+      sinon si rang = 2 alors 40%
+      sinon 0%
+    # Cas impossible : rôle est toujours Enfant dans cette exception.
+    -- n'importe quel : 0%
+```
+
+En cas de naissances multiples, tous
+les enfants jumeaux suivent la même règle : si les jumeaux sont précédés par 2
+autres enfants plus âgés, l'ensemble des jumeaux se voit attribuer le même
+pourcentage (la règle ne se limite donc pas à 3 enfants)
+
+```catala
+champ d'application CalculMontantForfaitaireGlobal:
+  définition rôles_avec_rang égal à
+    soit (résultat_rôles_avec_rang, date_naissance_dernier_enfant, rang_dernier_enfant_plus_un, nombre_jumeaux_même_date) égal à
+      combinaison de (rôles_avec_rang, date_de_naissance_enfant_précédent, rang_enfant, nombre_jumeaux_même_date)
+        initialement ( [], |1900-01-01|, (0), (1) )
+        avec (
+          selon personne.rôle sous forme
+          -- Rôle.Demandeur :
+            (
+                  rôles_avec_rang
+                  ++ [ RôleAvecRang.Demandeur ],
+                  date_de_naissance_enfant_précédent,
+                  rang_enfant,
+                  nombre_jumeaux_même_date
+            )
+          -- Rôle.Conjoint :
+              (
+                    rôles_avec_rang
+                    ++ [ RôleAvecRang.Conjoint ],
+                    date_de_naissance_enfant_précédent,
+                    rang_enfant,
+                    nombre_jumeaux_même_date
+              )
+          -- Rôle.Enfant :
+                si personne.date_naissance = date_de_naissance_enfant_précédent alors
+                  (
+                        rôles_avec_rang
+                        ++ [ RôleAvecRang.Enfant contenu (rang_enfant - nombre_jumeaux_même_date) ],
+                        date_de_naissance_enfant_précédent, rang_enfant + 1 ,
+                        nombre_jumeaux_même_date + 1
+                  )
+                sinon
+                  (
+                        rôles_avec_rang
+                        ++ [ RôleAvecRang.Enfant contenu (rang_enfant) ],
+                        personne.date_naissance, (rang_enfant + 1),
+                        1
+                  )
+        )
+        pour personne parmi personnes
+    dans
+    résultat_rôles_avec_rang
+
+  définition montants_forfaitaires_individuel égal à
+    (
+      résultat de CalculMontantForfaitairePersonne avec {
+        -- mois_de_droit_à_calculer: mois_de_droit_à_calculer
+        -- foyer_isolé: foyer_isolé
+        -- rôle: rôle_avec_rang
+      }
+    )
+      pour (personne, rôle_avec_rang) parmi (personnes, rôles_avec_rang)
+```
+
+Barème
+
+à compter du Montant forfaitaire de base
+------------ --------------------------
+01-04-2019   559,74
+01-04-2020   564,78
+01-04-2021   565,34
+01-04-2022   566,42
+
+```catala
+champ d'application CalculMontantForfaitairePersonne:
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2019-04-01| et mois_de_droit_à_calculer < |2020-04-01|
+  conséquence égal à 559,74 €
+
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2020-04-01| et mois_de_droit_à_calculer < |2021-04-01|
+  conséquence égal à 564,78 €
+
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2021-04-01| et mois_de_droit_à_calculer < |2022-04-01|
+  conséquence égal à 565,34 €
+
+  définition montant_forfaitaire_base sous condition
+    mois_de_droit_à_calculer >= |2022-04-01|
+  conséquence égal à 566,42 €
+```
+
+## Réaliser un whatif permettant de vérifier le bon fonctionnement du moteur
+
+Modéliser des cas avec:
+
+* 1 demandeur seul
+
+```catala
+déclaration champ d'application Test1:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test1:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes: [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ]
+    }
+```
+
+* 1 demandeur 1 conjoint
+
+```catala
+déclaration champ d'application Test2:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test2:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ]
+    }
+```
+
+* et varier ces 2 cas principaux avec respectivement
+* aucun enfant
+* 1 seul enfant
+
+```catala
+déclaration champ d'application Test3:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test3:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+
+déclaration champ d'application Test4:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test4:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+```
+* 2 enfants
+
+```catala
+déclaration champ d'application Test5:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test5:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ]
+    }
+
+déclaration champ d'application Test6:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test6:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ]
+    }
+```
+
+* 3 enfants
+
+```catala
+déclaration champ d'application Test7:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test7:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test8:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test8:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```
+
+* 5 enfants
+
+```catala
+déclaration champ d'application Test9:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test9:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2013-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2014-01-01| } ]
+    }
+
+déclaration champ d'application Test10:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test10:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2013-01-01| } ;
+          Personne { -- identifiant: 6 -- rôle: Rôle.Enfant -- date_naissance: |2014-01-01| } ]
+    }
+```
+
+* 2 enfants jumeaux
+
+```catala
+déclaration champ d'application Test11:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test11:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+
+déclaration champ d'application Test12:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test12:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ]
+    }
+```
+
+* 4 enfants dont 2 jumeaux, les jumeaux étant les plus jeunes
+
+```catala
+déclaration champ d'application Test13:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test13:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test14:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test14:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```
+* 4 enfants dont 2 jumeaux, les jumeaux étant les plus âgés
+
+```catala
+déclaration champ d'application Test15:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test15:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test16:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test16:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2011-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```
+
+* 4 enfants dont 3 triplés, les jumeaux étant les plus jeunes
+
+```catala
+déclaration champ d'application Test17:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test17:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+
+déclaration champ d'application Test18:
+  résultat calcul contenu CalculMontantForfaitaireGlobal
+
+champ d'application Test18:
+  définition calcul égal à
+    résultat de CalculMontantForfaitaireGlobal avec {
+      -- foyer_isolé: faux
+      -- mois_de_droit_à_calculer: |2022-12-01|
+      -- personnes:
+        [ Personne { -- identifiant: 0 -- rôle: Rôle.Demandeur -- date_naissance: |1980-01-01| } ;
+          Personne { -- identifiant: 1 -- rôle: Rôle.Conjoint -- date_naissance: |1981-01-01| } ;
+          Personne { -- identifiant: 2 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 3 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 4 -- rôle: Rôle.Enfant -- date_naissance: |2010-01-01| } ;
+          Personne { -- identifiant: 5 -- rôle: Rôle.Enfant -- date_naissance: |2012-01-01| } ]
+    }
+```

--- a/tests/fr/tp_3_corrige.catala_fr.result
+++ b/tests/fr/tp_3_corrige.catala_fr.result
@@ -157,28 +157,28 @@ champ d'application CalculMontantForfaitaireGlobal:
                   nombre_jumeaux_même_date
             )
           -- Rôle.Conjoint :
+            (
+                  rôles_avec_rang
+                  ++ [ RôleAvecRang.Conjoint ],
+                  date_de_naissance_enfant_précédent,
+                  rang_enfant,
+                  nombre_jumeaux_même_date
+            )
+          -- Rôle.Enfant :
+            si personne.date_naissance = date_de_naissance_enfant_précédent alors
               (
                     rôles_avec_rang
-                    ++ [ RôleAvecRang.Conjoint ],
-                    date_de_naissance_enfant_précédent,
-                    rang_enfant,
-                    nombre_jumeaux_même_date
+                    ++ [ RôleAvecRang.Enfant contenu (rang_enfant - nombre_jumeaux_même_date) ],
+                    date_de_naissance_enfant_précédent, rang_enfant + 1 ,
+                    nombre_jumeaux_même_date + 1
               )
-          -- Rôle.Enfant :
-                si personne.date_naissance = date_de_naissance_enfant_précédent alors
-                  (
-                        rôles_avec_rang
-                        ++ [ RôleAvecRang.Enfant contenu (rang_enfant - nombre_jumeaux_même_date) ],
-                        date_de_naissance_enfant_précédent, rang_enfant + 1 ,
-                        nombre_jumeaux_même_date + 1
-                  )
-                sinon
-                  (
-                        rôles_avec_rang
-                        ++ [ RôleAvecRang.Enfant contenu (rang_enfant) ],
-                        personne.date_naissance, (rang_enfant + 1),
-                        1
-                  )
+            sinon
+              (
+                    rôles_avec_rang
+                    ++ [ RôleAvecRang.Enfant contenu (rang_enfant) ],
+                    personne.date_naissance, (rang_enfant + 1),
+                    1
+              )
         )
         pour personne parmi personnes
     dans


### PR DESCRIPTION
Fixes:
- Incorrect anti-space handling in some situation, i.e., when an integer directly is followed by a comma which can lead to error in catala_fr;
- Some tuple declaration would have spurious space before the closing parenthesis;
- Multiline pattern-matching cases indentation space would get larger and larger linearly with the number of cases.

Closes https://github.com/CatalaLang/catala-language-server/issues/78