### PR TITLE
Rehaul of the formatting rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ tests/*/*.changed
 target/
 
 **/_build
+
+**/#*
+**/.#*
+*.~*~
+.envrc
+.direnv

--- a/catala.ncl
+++ b/catala.ncl
@@ -5,7 +5,7 @@
       extensions = ["catala_en"],
       grammar = {
         git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "d988caadc962a6adef17857f7de744904889caff",
+        rev = "2c81e816d03f84774afd492c82ffd1ed1ab98fb6",
         subdir = "en",
       }
     },
@@ -14,7 +14,7 @@
       extensions = ["catala_fr"],
       grammar = {
         git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "d988caadc962a6adef17857f7de744904889caff",
+        rev = "2c81e816d03f84774afd492c82ffd1ed1ab98fb6",
         subdir = "fr",
       }
     },
@@ -23,7 +23,7 @@
       extensions = ["catala_pl"],
       grammar = {
         git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "d988caadc962a6adef17857f7de744904889caff",
+        rev = "2c81e816d03f84774afd492c82ffd1ed1ab98fb6",
         subdir = "pl",
       }
     }

--- a/catala.ncl
+++ b/catala.ncl
@@ -5,7 +5,7 @@
       extensions = ["catala_en"],
       grammar = {
         git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "2c81e816d03f84774afd492c82ffd1ed1ab98fb6",
+        rev = "6c3edbcc",
         subdir = "en",
       }
     },
@@ -14,7 +14,7 @@
       extensions = ["catala_fr"],
       grammar = {
         git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "2c81e816d03f84774afd492c82ffd1ed1ab98fb6",
+        rev = "6c3edbcc",
         subdir = "fr",
       }
     },
@@ -23,7 +23,7 @@
       extensions = ["catala_pl"],
       grammar = {
         git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "2c81e816d03f84774afd492c82ffd1ed1ab98fb6",
+        rev = "6c3edbcc",
         subdir = "pl",
       }
     }

--- a/catala.scm
+++ b/catala.scm
@@ -478,6 +478,13 @@
 
 (e_match . ((WITH_PATT) @append_spaced_softline) (_))
 
+;; x with pattern Foo content y and ...
+(e_binop
+ lhs: (e_test_match (WITH_PATT) @prepend_spaced_scoped_softline (CONTENT)) @prepend_begin_scope
+ op: (AND) @prepend_spaced_scoped_softline @append_end_scope
+ (#scope_id! "with_patt_and")
+)
+
 ;; Pattern-matching cases
 
 ((ALT) . (match_case ((COLON) @prepend_space @append_spaced_softline @append_indent_start) (_) @append_indent_end .)) @prepend_spaced_softline

--- a/catala.scm
+++ b/catala.scm
@@ -440,7 +440,7 @@
 
 (e_tuple
  (tuple_contents
-  (COMMA)? @append_input_softline)
+  (COMMA)? @append_spaced_scoped_softline)
  (#scope_id! "e_tuple")
 )
 
@@ -454,7 +454,7 @@
 
 (binder
  (var_list
-  (COMMA)? @append_input_softline
+  (COMMA)? @append_spaced_scoped_softline
  )
  (#scope_id! "binder")
 )
@@ -694,8 +694,8 @@
 
 ((SUM) @prepend_begin_scope @append_indent_start
  (_)
- (OF) @append_spaced_scoped_softline @append_indent_end
- (e_coll_map . (_) @append_end_scope)
+ (OF) @append_spaced_scoped_softline
+ (e_coll_map . (_) @append_end_scope) @append_indent_end
  (#scope_id! "aggregate")
 )
 

--- a/catala.scm
+++ b/catala.scm
@@ -560,6 +560,7 @@
  (#multi_line_only!)
 )
 
+((module_name) (DOT) @prepend_antispace . (module_name))
 ((module_name) (DOT) @prepend_antispace . (variable))
 ((module_name) (DOT) @prepend_antispace . (scope_name))
 

--- a/tests/en/date_en.catala_en.result
+++ b/tests/en/date_en.catala_en.result
@@ -6,7 +6,8 @@
 ## Returns the earlier of two dates
 declaration min
   content date
-  depends on x content date,
+  depends on
+    x content date,
     y content date
   equals
     if x <= y then x else y
@@ -14,7 +15,8 @@ declaration min
 ## Returns the latter of two dates
 declaration max
   content date
-  depends on x content date,
+  depends on
+    x content date,
     y content date
   equals
     if x >= y then x else y
@@ -22,12 +24,13 @@ declaration max
 declaration of_year_month_day
   content date
   depends on
-  #[implicit_position_argument]
+    #[implicit_position_argument]
     pos content code_location,
     dyear content integer,
     dmonth content integer,
     dday content integer
-  equals D.of_ymd of pos, dyear, dmonth, dday
+  equals
+    D.of_ymd of pos, dyear, dmonth, dday
 
 declaration to_year_month_day
   content (integer, integer, integer)
@@ -38,22 +41,26 @@ declaration to_year_month_day
 declaration last_day_of_month
   content date
   depends on d content date
-  equals D.last_day_of_month of d
+  equals
+    D.last_day_of_month of d
 
 declaration get_year
   content integer
   depends on d content date
-  equals (to_year_month_day of d).1
+  equals
+    (to_year_month_day of d).1
 
 declaration get_month
   content integer
   depends on d content date
-  equals (to_year_month_day of d).2
+  equals
+    (to_year_month_day of d).2
 
 declaration get_day
   content integer
   depends on d content date
-  equals (to_year_month_day of d).3
+  equals
+    (to_year_month_day of d).3
 
 declaration first_day_of_month
   content date

--- a/tests/en/date_internal.catala_en.result
+++ b/tests/en/date_internal.catala_en.result
@@ -3,7 +3,8 @@
 ```catala-metadata
 declaration of_ymd
   content date
-  depends on pos content code_location,
+  depends on
+    pos content code_location,
     dyear content integer,
     dmonth content integer,
     dday content integer

--- a/tests/en/nsw_art_union.catala_en.result
+++ b/tests/en/nsw_art_union.catala_en.result
@@ -62,7 +62,7 @@ scope GamingAuthorized:
   definition authority equals artUnion.holdsAuthority
 
 scope GamingAuthorized:
-  rule authorized under condition
-    minimumProceeds and benefitingOrg and valueOfPrizes and separatePrizeMaxValue and authority
+  rule authorized
+  under condition minimumProceeds and benefitingOrg and valueOfPrizes and separatePrizeMaxValue and authority
   consequence fulfilled
 ```

--- a/tests/en/nsw_charity_housie.catala_en.result
+++ b/tests/en/nsw_charity_housie.catala_en.result
@@ -58,7 +58,7 @@ scope GamingAuthorized:
   definition maxTickets equals charityHousie.maxTicketsPerParticipant <= 48
 
 scope GamingAuthorized:
-  rule authorized under condition
-    benefitingOrg and minimumProceeds and expenses and prizesTotal and maxTickets
+  rule authorized
+  under condition benefitingOrg and minimumProceeds and expenses and prizesTotal and maxTickets
   consequence fulfilled
 ```

--- a/tests/en/nsw_club_bingo.catala_en.result
+++ b/tests/en/nsw_club_bingo.catala_en.result
@@ -34,7 +34,7 @@ scope GamingAuthorized:
 ```catala
 scope GamingAuthorized:
   definition bonusPrize equals
-    ((clubBingo.bonusPrizeMaxValue <= $70) or (not clubBingo.bonusPrizeOffered))
+  ((clubBingo.bonusPrizeMaxValue <= $70) or (not clubBingo.bonusPrizeOffered))
 ```
 
 (d)  none of the prizes consist of or include money.
@@ -42,7 +42,7 @@ scope GamingAuthorized:
 scope GamingAuthorized:
   definition contentPrize equals not clubBingo.prizeContent
 
-  rule authorized under condition
-    conductor and prizeValueIsSmall and bonusPrize and contentPrize
+  rule authorized
+  under condition conductor and prizeValueIsSmall and bonusPrize and contentPrize
   consequence fulfilled
 ```

--- a/tests/en/nsw_draw_lottery.catala_en.result
+++ b/tests/en/nsw_draw_lottery.catala_en.result
@@ -44,7 +44,7 @@ scope GamingAuthorized:
   definition maxValueOfPrizes equals drawLottery.totalValueOfThePrizes <= $30,000
 
 scope GamingAuthorized:
-  rule authorized under condition
-    benefitingOrg and minimumProceeds and maxValueOfPrizes
+  rule authorized
+  under condition benefitingOrg and minimumProceeds and maxValueOfPrizes
   consequence fulfilled
 ```

--- a/tests/en/nsw_no_draw_lottery.catala_en.result
+++ b/tests/en/nsw_no_draw_lottery.catala_en.result
@@ -52,7 +52,7 @@ scope GamingAuthorized:
   definition maxTicketsProduced equals noDrawLottery.maxTickets <= 3000
 
 scope GamingAuthorized:
-  rule authorized under condition
-    benefitingOrg and minimumProceeds and maxValueOfPrizes and maxTicketsProduced
+  rule authorized
+  under condition benefitingOrg and minimumProceeds and maxValueOfPrizes and maxTicketsProduced
   consequence fulfilled
 ```

--- a/tests/en/nsw_progressive_lottery.catala_en.result
+++ b/tests/en/nsw_progressive_lottery.catala_en.result
@@ -29,13 +29,13 @@ scope GamingAuthorized:
 ```catala
 scope GamingAuthorized:
   definition amountOfPrizesGreaterThan30000 equals
-    (
-      progressiveLottery.totalValueOfThePrizes < $30000
-      or progressiveLottery.holdsAuthority
-    )
+  (
+    progressiveLottery.totalValueOfThePrizes < $30000
+    or progressiveLottery.holdsAuthority
+  )
 
 scope GamingAuthorized:
-  rule authorized under condition
-    maxCashPrize and amountOfPrizesGreaterThan30000
+  rule authorized
+  under condition maxCashPrize and amountOfPrizesGreaterThan30000
   consequence fulfilled
 ```

--- a/tests/en/nsw_social_housie.catala_en.result
+++ b/tests/en/nsw_social_housie.catala_en.result
@@ -65,7 +65,7 @@ deducted,is returned to participants.
 scope GamingAuthorized:
   definition returnInvestment equals socialHousie.investmentReturn
 
-  rule authorized under condition
-    purpose and licence and prizePrice and maxJackpotValue and returnInvestment
+  rule authorized
+  under condition purpose and licence and prizePrice and maxJackpotValue and returnInvestment
   consequence fulfilled
 ```

--- a/tests/en/section_121.catala_en.result
+++ b/tests/en/section_121.catala_en.result
@@ -192,18 +192,19 @@ scope Section121SinglePerson:
   # Regulation 1.121-1(c)(1): 2 years = 730 days
   # Regulation 1.121-1(c)(1): the periods of ownage and usage
   # don't have to overlap
-  rule requirements_ownership_met under condition
-    aggregate_periods_from_last_five_years of property_ownage >= 730 day
+  rule requirements_ownership_met
+  under condition aggregate_periods_from_last_five_years of property_ownage >= 730 day
   consequence fulfilled
 
-  rule requirements_usage_met under condition
+  rule requirements_usage_met
+  under condition
     aggregate_periods_from_last_five_years of
       property_usage_as_principal_residence
     >= 730 day
   consequence fulfilled
 
-  rule requirements_met under condition
-    requirements_ownership_met and requirements_usage_met
+  rule requirements_met
+  under condition requirements_ownership_met and requirements_usage_met
   consequence fulfilled
 
   definition income_excluded_from_gross_income_uncapped equals
@@ -275,16 +276,17 @@ respect to such property by reason of paragraph (3).
 
 ```catala
 scope Section121TwoPersons:
-  rule section_121_b_2_A_condition under condition
+  rule section_121_b_2_A_condition
+  under condition
     (return_type with pattern JointReturn)
     and
-    # i)
+      # i)
     (
       section121Person1.requirements_ownership_met
       or section121Person2.requirements_ownership_met
     )
     and
-    # ii)
+      # ii)
     (
       section121Person1.requirements_usage_met
       and section121Person2.requirements_usage_met
@@ -295,14 +297,15 @@ scope Section121TwoPersons:
   consequence fulfilled
 
   exception
-  rule section121a_requirements_met under condition
-    section_121_b_2_A_condition
+  rule section121a_requirements_met
+  under condition section_121_b_2_A_condition
   consequence fulfilled
 
   exception
-  definition gain_cap under condition
-    section_121_b_2_A_condition
-  consequence equals $500,000
+  definition gain_cap
+  under condition section_121_b_2_A_condition
+  consequence equals
+    $500,000
 ```
 
 ##### (B) Other joint returns
@@ -315,7 +318,8 @@ property during the period that either spouse owned the property.
 
 ```catala
 scope Section121TwoPasses
-  under condition (return_type with pattern JointReturn)
+under condition
+  (return_type with pattern JointReturn)
   and not (first_pass.section_121_b_2_A_condition):
 
   definition second_pass.gain_cap equals
@@ -360,15 +364,17 @@ was any other sale or exchange by the taxpayer to which subsection (a) applied.
 
 ```catala
 scope Section121SinglePerson:
-  rule section_121_b_3_applies under condition
+  rule section_121_b_3_applies
+  under condition
     other_section_121a_sale with pattern MostRecentSaleWhereSection121aApplied content other_sale
     and date_of_sale_or_exchange - other_sale.date_of_sale_or_exchange <= 2 year
   consequence fulfilled
 
   exception
-  definition income_excluded_from_gross_income_uncapped under condition
-    section_121_b_3_applies
-  consequence equals $0
+  definition income_excluded_from_gross_income_uncapped
+  under condition section_121_b_3_applies
+  consequence equals
+    $0
 ```
 
 #### (4) Special rule for certain sales by surviving spouses
@@ -385,7 +391,8 @@ years after the date of death of such spouse and the requirements of paragraph
 
 ```catala
 scope Section121TwoPasses
-  under condition return_type with pattern SingleReturnSurvivingSpouse content single_data
+under condition
+  return_type with pattern SingleReturnSurvivingSpouse content single_data
   and single_data.date_of_spouse_death < date_of_sale_or_exchange
   and date_of_sale_or_exchange <= single_data.date_of_spouse_death + 2 year:
 
@@ -410,9 +417,10 @@ scope Section121TwoPasses
     -- JointReturn content return : JointReturn content return
   # does not happen
 
-  definition second_pass.gain_cap under condition
-    first_pass.section_121_b_2_A_condition
-  consequence equals $500,000
+  definition second_pass.gain_cap
+  under condition first_pass.section_121_b_2_A_condition
+  consequence equals
+    $500,000
 ```
 
 #### (5) Exclusion of gain allocated to nonqualified use

--- a/tests/en/section_121.catala_en.result
+++ b/tests/en/section_121.catala_en.result
@@ -366,7 +366,8 @@ was any other sale or exchange by the taxpayer to which subsection (a) applied.
 scope Section121SinglePerson:
   rule section_121_b_3_applies
   under condition
-    other_section_121a_sale with pattern MostRecentSaleWhereSection121aApplied content other_sale
+    other_section_121a_sale
+    with pattern MostRecentSaleWhereSection121aApplied content other_sale
     and date_of_sale_or_exchange - other_sale.date_of_sale_or_exchange <= 2 year
   consequence fulfilled
 
@@ -392,7 +393,8 @@ years after the date of death of such spouse and the requirements of paragraph
 ```catala
 scope Section121TwoPasses
 under condition
-  return_type with pattern SingleReturnSurvivingSpouse content single_data
+  return_type
+  with pattern SingleReturnSurvivingSpouse content single_data
   and single_data.date_of_spouse_death < date_of_sale_or_exchange
   and date_of_sale_or_exchange <= single_data.date_of_spouse_death + 2 year:
 

--- a/tests/en/section_132.catala_en.result
+++ b/tests/en/section_132.catala_en.result
@@ -40,11 +40,13 @@ the property is being offered by the employer to customers, or
 
 ```catala
 scope QualifiedEmployeeDiscount:
-  definition qualified_employee_discount under condition
-    is_property
+  definition qualified_employee_discount
+  under condition is_property
   consequence equals
-    if employee_discount
-      > customer_price * gross_profit_percentage then
+    if
+      employee_discount
+      > customer_price * gross_profit_percentage
+    then
       customer_price * gross_profit_percentage
     else employee_discount
 ```
@@ -54,15 +56,18 @@ being offered by the employer to customers.
 
 ```catala
 scope QualifiedEmployeeDiscount:
-  definition qualified_employee_discount under condition
-    is_services
+  definition qualified_employee_discount
+  under condition is_services
   consequence equals
-    if employee_discount
-      > customer_price * 20% then
+    if
+      employee_discount
+      > customer_price * 20%
+    then
       customer_price * 20%
     else employee_discount
 
-scope QualifiedEmployeeDiscount under condition is_services:
+scope QualifiedEmployeeDiscount
+under condition is_services:
   # When selling a service, one does not need the aggregate cost.
   # We provide a default value here so that the computations run smooth.
   definition aggregate_cost equals $0
@@ -81,7 +86,8 @@ to customers over the aggregate cost of such property to the employer, is of
 (ii) the aggregate sale price of such property.
 
 ```catala
-scope QualifiedEmployeeDiscount under condition is_property:
+scope QualifiedEmployeeDiscount
+under condition is_property:
   assertion customer_price >= aggregate_cost
 
   definition gross_profit_percentage equals

--- a/tests/en/section_152.catala_en.result
+++ b/tests/en/section_152.catala_en.result
@@ -82,8 +82,8 @@ than one-half of such taxable year,
 
 ```catala
 scope BaseChildTaxpayerQualification:
-  rule residence_requirement under condition
-    same_residence_child_taxpayer
+  rule residence_requirement
+  under condition same_residence_child_taxpayer
   consequence fulfilled
 ```
 
@@ -100,7 +100,8 @@ of the taxpayer begins.
 
 ```catala
 scope BaseChildTaxpayerQualification:
-  rule is_qualifying under condition
+  rule is_qualifying
+  under condition
     relationship_requirement
     and residence_requirement
     and age_requirement

--- a/tests/en/test_section_121.catala_en.result
+++ b/tests/en/test_section_121.catala_en.result
@@ -44,7 +44,7 @@ scope Data:
     PersonalData {
       -- property_ownage: [ period_four_years_recent ]
       -- property_usage_as_principal_residence:
-        [ period_two_years_middle ; period_one_year_recent ]
+        [ period_two_years_middle; period_one_year_recent ]
       -- other_section_121a_sale: NoOtherSaleWhereSection121aApplied
     }
   definition person_ko_1 equals
@@ -119,7 +119,7 @@ scope Test4:
     data_.gain_from_sale_or_exchange_of_property
   definition scope121a.property_ownage equals [ data_.period_four_years_recent ]
   definition scope121a.property_usage_as_principal_residence equals
-    [ data_.period_two_years_middle ; data_.period_one_year_recent ]
+    [ data_.period_two_years_middle; data_.period_one_year_recent ]
   definition scope121a.other_section_121a_sale equals NoOtherSaleWhereSection121aApplied
   assertion scope121a.requirements_met
 

--- a/tests/en/tutorial_end_2_2.catala_en.result
+++ b/tests/en/tutorial_end_2_2.catala_en.result
@@ -29,9 +29,10 @@ The fixed percentage mentioned at article 1 is equal to 20 %.
 ```catala
 scope IncomeTaxComputation:
   label article_2
-  definition tax_rate under condition
-    current_date < |2000-01-01|
-  consequence equals 20%
+  definition tax_rate
+  under condition current_date < |2000-01-01|
+  consequence equals
+    20%
 ```
 
 ## Article 2 (new version after 2000)
@@ -43,9 +44,10 @@ scope IncomeTaxComputation:
   # Simply use the same label "article_2" as the previous definition to group
   # them together
   label article_2
-  definition tax_rate under condition
-    current_date >= |2000-01-01|
-  consequence equals 21%
+  definition tax_rate
+  under condition current_date >= |2000-01-01|
+  consequence equals
+    21%
 ```
 
 ## Article 3
@@ -56,9 +58,10 @@ percentage mentioned at article 1 is equal to 15 %.
 ```catala
 scope IncomeTaxComputation:
   label article_3 exception article_2
-  definition tax_rate under condition
-    individual.number_of_children >= 2
-  consequence equals 15%
+  definition tax_rate
+  under condition individual.number_of_children >= 2
+  consequence equals
+    15%
 ```
 
 ## Article 4
@@ -69,9 +72,10 @@ at article 1.
 ```catala
 scope IncomeTaxComputation:
   label article_4 exception article_3
-  definition tax_rate under condition
-    individual.income <= $10,000
-  consequence equals 0%
+  definition tax_rate
+  under condition individual.income <= $10,000
+  consequence equals
+    0%
 ```
 
 ## Article 5
@@ -82,9 +86,10 @@ Individuals earning more than $100,000 are subjects to a tax rate of
 ```catala
 scope IncomeTaxComputation:
   label article_5 exception article_3
-  definition tax_rate under condition
-    individual.income > $100,000
-  consequence equals 30%
+  definition tax_rate
+  under condition individual.income > $100,000
+  consequence equals
+    30%
 ```
 
 ## Article 6
@@ -95,9 +100,10 @@ more than $100,000 specified at article 5 is reduced to 25 %.
 ```catala
 scope IncomeTaxComputation:
   label article_6 exception article_5
-  definition tax_rate under condition
-    individual.income > $100,000 and overseas_territories
-  consequence equals 25%
+  definition tax_rate
+  under condition individual.income > $100,000 and overseas_territories
+  consequence equals
+    25%
 ```
 
 ## Test

--- a/tests/en/tutorial_end_2_3.catala_en.result
+++ b/tests/en/tutorial_end_2_3.catala_en.result
@@ -29,9 +29,10 @@ The fixed percentage mentioned at article 1 is equal to 20 %.
 ```catala
 scope IncomeTaxComputation:
   label article_2
-  definition tax_rate under condition
-    current_date < |2000-01-01|
-  consequence equals 20%
+  definition tax_rate
+  under condition current_date < |2000-01-01|
+  consequence equals
+    20%
 ```
 
 ## Article 2 (new version after 2000)
@@ -43,9 +44,10 @@ scope IncomeTaxComputation:
   # Simply use the same label "article_2" as the previous definition to group
   # them together
   label article_2
-  definition tax_rate under condition
-    current_date >= |2000-01-01|
-  consequence equals 21%
+  definition tax_rate
+  under condition current_date >= |2000-01-01|
+  consequence equals
+    21%
 ```
 
 ## Article 3
@@ -56,9 +58,10 @@ percentage mentioned at article 1 is equal to 15 %.
 ```catala
 scope IncomeTaxComputation:
   label article_3 exception article_2
-  definition tax_rate under condition
-    individual.number_of_children >= 2
-  consequence equals 15%
+  definition tax_rate
+  under condition individual.number_of_children >= 2
+  consequence equals
+    15%
 ```
 
 ## Article 4
@@ -69,9 +72,10 @@ at article 1.
 ```catala
 scope IncomeTaxComputation:
   label article_4 exception article_3
-  definition tax_rate under condition
-    individual.income <= $10,000
-  consequence equals 0%
+  definition tax_rate
+  under condition individual.income <= $10,000
+  consequence equals
+    0%
 ```
 
 ## Article 5
@@ -82,9 +86,10 @@ Individuals earning more than $100,000 are subjects to a tax rate of
 ```catala
 scope IncomeTaxComputation:
   label article_5 exception article_3
-  definition tax_rate under condition
-    individual.income > $100,000
-  consequence equals 30%
+  definition tax_rate
+  under condition individual.income > $100,000
+  consequence equals
+    30%
 ```
 
 ## Article 6
@@ -95,9 +100,10 @@ more than $100,000 specified at article 5 is reduced to 25 %.
 ```catala
 scope IncomeTaxComputation:
   label article_6 exception article_5
-  definition tax_rate under condition
-    individual.income > $100,000 and overseas_territories
-  consequence equals 25%
+  definition tax_rate
+  under condition individual.income > $100,000 and overseas_territories
+  consequence equals
+    25%
 ```
 
 ## Article 7
@@ -134,8 +140,8 @@ scope HouseholdTaxComputation:
   definition household_tax equals
     let number_of_individuals equals number of individuals in
     let number_of_children equals
-      sum integer
-        of map each individual among individuals to
+      sum integer of
+      map each individual among individuals to
         individual.number_of_children
     in
     $10,000
@@ -193,14 +199,16 @@ scope TestHousehold:
   definition computation equals
     output of HouseholdTaxComputation with {
       -- individuals:
-        [ Individual {
+        [
+          Individual {
             -- income: $15,000
             -- number_of_children: 0
-          } ;
+          };
           Individual {
             -- income: $80,000
             -- number_of_children: 2
-          } ]
+          }
+        ]
     }
 
 declaration scope TestIndividualHousehold:

--- a/tests/en/tutorial_end_2_3.catala_en.result
+++ b/tests/en/tutorial_end_2_3.catala_en.result
@@ -141,8 +141,8 @@ scope HouseholdTaxComputation:
     let number_of_individuals equals number of individuals in
     let number_of_children equals
       sum integer of
-      map each individual among individuals to
-        individual.number_of_children
+        map each individual among individuals to
+          individual.number_of_children
     in
     $10,000
     * (

--- a/tests/en/tutorial_end_2_4.catala_en.result
+++ b/tests/en/tutorial_end_2_4.catala_en.result
@@ -159,8 +159,8 @@ scope HouseholdTaxComputation:
     state base
   equals
     sum money of
-    map each share_of_household_tax among shares_of_household_tax to
-      share_of_household_tax.household_tax
+      map each share_of_household_tax among shares_of_household_tax to
+        share_of_household_tax.household_tax
 ```
 
 ## Article 8
@@ -187,8 +187,8 @@ scope HouseholdTaxComputation:
     state base
   equals
     sum money of
-    map each share_of_household_tax among shares_of_household_tax to
-      share_of_household_tax.deduction
+      map each share_of_household_tax among shares_of_household_tax to
+        share_of_household_tax.deduction
 
   definition household_tax
     state deduction

--- a/tests/en/tutorial_end_2_4.catala_en.result
+++ b/tests/en/tutorial_end_2_4.catala_en.result
@@ -29,9 +29,10 @@ The fixed percentage mentioned at article 1 is equal to 20 %.
 ```catala
 scope IncomeTaxComputation:
   label article_2
-  definition tax_rate under condition
-    current_date < |2000-01-01|
-  consequence equals 20%
+  definition tax_rate
+  under condition current_date < |2000-01-01|
+  consequence equals
+    20%
 ```
 
 ## Article 2 (new version after 2000)
@@ -43,9 +44,10 @@ scope IncomeTaxComputation:
   # Simply use the same label "article_2" as the previous definition to group
   # them together
   label article_2
-  definition tax_rate under condition
-    current_date >= |2000-01-01|
-  consequence equals 21%
+  definition tax_rate
+  under condition current_date >= |2000-01-01|
+  consequence equals
+    21%
 ```
 
 ## Article 3
@@ -56,9 +58,10 @@ percentage mentioned at article 1 is equal to 15 %.
 ```catala
 scope IncomeTaxComputation:
   label article_3 exception article_2
-  definition tax_rate under condition
-    individual.number_of_children >= 2
-  consequence equals 15%
+  definition tax_rate
+  under condition individual.number_of_children >= 2
+  consequence equals
+    15%
 ```
 
 ## Article 4
@@ -69,9 +72,10 @@ at article 1.
 ```catala
 scope IncomeTaxComputation:
   label article_4 exception article_3
-  definition tax_rate under condition
-    individual.income <= $10,000
-  consequence equals 0%
+  definition tax_rate
+  under condition individual.income <= $10,000
+  consequence equals
+    0%
 ```
 
 ## Article 5
@@ -82,9 +86,10 @@ Individuals earning more than $100,000 are subjects to a tax rate of
 ```catala
 scope IncomeTaxComputation:
   label article_5 exception article_3
-  definition tax_rate under condition
-    individual.income > $100,000
-  consequence equals 30%
+  definition tax_rate
+  under condition individual.income > $100,000
+  consequence equals
+    30%
 ```
 
 ## Article 6
@@ -95,9 +100,10 @@ more than $100,000 specified at article 5 is reduced to 25 %.
 ```catala
 scope IncomeTaxComputation:
   label article_6 exception article_5
-  definition tax_rate under condition
-    individual.income > $100,000 and overseas_territories
-  consequence equals 25%
+  definition tax_rate
+  under condition individual.income > $100,000 and overseas_territories
+  consequence equals
+    25%
 ```
 
 ## Article 7
@@ -152,8 +158,8 @@ scope HouseholdTaxComputation:
   definition household_tax
     state base
   equals
-    sum money
-      of map each share_of_household_tax among shares_of_household_tax to
+    sum money of
+    map each share_of_household_tax among shares_of_household_tax to
       share_of_household_tax.household_tax
 ```
 
@@ -180,8 +186,8 @@ scope HouseholdTaxComputation:
   definition total_deduction
     state base
   equals
-    sum money
-      of map each share_of_household_tax among shares_of_household_tax to
+    sum money of
+    map each share_of_household_tax among shares_of_household_tax to
       share_of_household_tax.deduction
 
   definition household_tax
@@ -228,14 +234,16 @@ scope TestHousehold:
   definition computation equals
     output of HouseholdTaxComputation with {
       -- individuals:
-        [ Individual {
+        [
+          Individual {
             -- income: $15,000
             -- number_of_children: 0
-          } ;
+          };
           Individual {
             -- income: $80,000
             -- number_of_children: 2
-          } ]
+          }
+        ]
       -- overseas_territories: false
       -- current_date: |1999-01-01|
     }

--- a/tests/fr/Bmaf.catala_fr.result
+++ b/tests/fr/Bmaf.catala_fr.result
@@ -29,10 +29,12 @@ familiales, est ainsi porté de 411,92 € à 413,16 € au 1er avril 2019.
 
 ```catala
 champ d'application BaseMensuelleAllocationsFamiliales:
-  définition montant sous condition
+  définition montant
+  sous condition
     date_courante >= |2019-04-01|
     et date_courante < |2020-04-01|
-  conséquence égal à 413,16 €
+  conséquence égal à
+    413,16 €
 ```
 
 ## Instruction interministérielle no DSS/SD2B/2020/33 du 18 février 2020 relative à la revalorisation au 1er avril 2020 des prestations familiales servies en métropole, en Guadeloupe, en Guyane, en Martinique, à La Réunion, à Saint-Barthélemy, à Saint-Martin et dans le département de Mayotte
@@ -48,10 +50,12 @@ est ainsi porté de 413,16 € à 414,4 € au 1er avril 2020.
 
 ```catala
 champ d'application BaseMensuelleAllocationsFamiliales:
-  définition montant sous condition
+  définition montant
+  sous condition
     date_courante >= |2020-04-01|
     et date_courante < |2021-04-01|
-  conséquence égal à 414,4 €
+  conséquence égal à
+    414,4 €
 ```
 
 ## Instruction interministérielle n°DSS/2B/2021/65 du 19 mars 2021 relative à la revalorisation au 1er avril 2021 des prestations familiales servies en métropole, en Guadeloupe, en Guyane, en Martinique, à la Réunion, à Saint-Barthélemy, à Saint-Martin et dans le département de Mayotte
@@ -63,10 +67,12 @@ est donc porté de 414,4 € au 1er avril 2020 à 414,81 € au 1er avril 2021.
 
 ```catala
 champ d'application BaseMensuelleAllocationsFamiliales:
-  définition montant sous condition
+  définition montant
+  sous condition
     date_courante >= |2021-04-01|
     et date_courante < |2022-04-01|
-  conséquence égal à 414,81 €
+  conséquence égal à
+    414,81 €
 ```
 
 ## Instruction interministérielle n°DSS/2B/2022/82 du 28 mars 2022 relative à la revalorisation au 1er avril 2022 des prestations familiales servies en métropole, en Guadeloupe, en Guyane, en Martinique, à la Réunion, à Saint-Barthélemy, à Saint-Martin et dans le département de Mayotte
@@ -79,10 +85,12 @@ de 414,81 € au 1er avril 2021 à 422,28 € au 1er avril 2022.
 
 ```catala
 champ d'application BaseMensuelleAllocationsFamiliales:
-  définition montant sous condition
+  définition montant
+  sous condition
     date_courante >= |2022-04-01|
     et date_courante < |2023-04-01|
-  conséquence égal à 422,28 €
+  conséquence égal à
+    422,28 €
 ```
 
 ## Instruction interministérielle N° DSS/2B/2023/41 du 24 mars 2023 relative à la revalorisation au 1er avril 2023 des prestations familiales servies en métropole, en Guadeloupe, en Guyane, en Martinique, à la Réunion, à Saint-Barthélemy, à Saint-Martin et dans le département de Mayotte
@@ -98,7 +106,8 @@ les prestations familiales, est donc porté à 445,93 €.
 
 ```catala
 champ d'application BaseMensuelleAllocationsFamiliales:
-  définition montant sous condition
-    date_courante >= |2023-04-01|
-  conséquence égal à 445,93 €
+  définition montant
+  sous condition date_courante >= |2023-04-01|
+  conséquence égal à
+    445,93 €
 ```

--- a/tests/fr/Smic.catala_fr.result
+++ b/tests/fr/Smic.catala_fr.result
@@ -32,7 +32,8 @@ son montant est porté à 10,03 € l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2019-01-01|
     et date_courante <= |2019-12-31|
     et (
@@ -45,20 +46,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 10,03 €
+  conséquence égal à
+    10,03 €
 ```
 
 2° A Mayotte, son montant est fixé à 7,57 € l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2019-01-01|
     et date_courante <= |2019-12-31|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 7,57 €
+  conséquence égal à
+    7,57 €
 ```
 
 ## Décret n° 2019-1387 du 18 décembre 2019 portant relèvement du salaire minimum de croissance
@@ -75,7 +79,8 @@ son montant est porté à 10,15 € l'heure ;
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2020-01-01|
     et date_courante <= |2020-12-31|
     et (
@@ -88,20 +93,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 10,15 €
+  conséquence égal à
+    10,15 €
 ```
 
 2° A Mayotte, son montant est fixé à 7,66 € l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2020-01-01|
     et date_courante <= |2020-12-31|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 7,66 €
+  conséquence égal à
+    7,66 €
 ```
 
 ## Décret n° 2020-1598 du 16 décembre 2020 portant relèvement du salaire minimum de croissance
@@ -118,7 +126,8 @@ son montant est porté à 10,25 € l'heure ;
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2021-01-01|
     et date_courante <= |2021-12-31|
     et (
@@ -131,20 +140,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 10,25 €
+  conséquence égal à
+    10,25 €
 ```
 
 2° A Mayotte, son montant est fixé à 7,74 € l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2021-01-01|
     et date_courante <= |2021-12-31|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 7,74 €
+  conséquence égal à
+    7,74 €
 ```
 
 ## Décret n° 2021-1741 du 22 décembre 2021 portant relèvement du salaire minimum de croissance
@@ -161,7 +173,8 @@ porté à 10,57 euros l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2022-01-01|
     et date_courante <= |2022-04-30|
     et (
@@ -174,20 +187,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 10,57 €
+  conséquence égal à
+    10,57 €
 ```
 
 2° A Mayotte, son montant est fixé à 7,98 euros l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2022-01-01|
     et date_courante <= |2022-04-30|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 7,98 €
+  conséquence égal à
+    7,98 €
 ```
 
 ## Arrêté du 19 avril 2022 relatif au relèvement du salaire minimum de croissance
@@ -204,7 +220,8 @@ est porté à 10,85 € l'heure ;
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2022-05-01|
     et date_courante <= |2022-07-31|
     et (
@@ -217,20 +234,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 10,85 €
+  conséquence égal à
+    10,85 €
 ```
 
 2° A Mayotte, son montant est fixé à 8,19 € l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2022-05-01|
     et date_courante <= |2022-07-31|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 8,19 €
+  conséquence égal à
+    8,19 €
 ```
 
 ## Arrêté du 29 juillet 2022 relatif au relèvement du salaire minimum de croissance
@@ -247,7 +267,8 @@ son montant est porté à 11,07 € l'heure ;
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2022-08-01|
     et date_courante <= |2022-12-31|
     et (
@@ -260,20 +281,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 11,07 €
+  conséquence égal à
+    11,07 €
 ```
 
 2° A Mayotte, son montant est fixé à 8,35 € l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2022-08-01|
     et date_courante <= |2022-12-31|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 8,35 €
+  conséquence égal à
+    8,35 €
 ```
 
 ## Décret n° 2022-1608 du 22 décembre 2022 portant relèvement du salaire minimum de croissance
@@ -291,7 +315,8 @@ son montant est porté à 11,27 euros l'heure ;
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2023-01-01|
     et date_courante < |2023-05-01|
     et (
@@ -304,20 +329,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 11,27 €
+  conséquence égal à
+    11,27 €
 ```
 
 2° A Mayotte, son montant est fixé à 8,51 euros l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2023-01-01|
     et date_courante < |2023-05-01|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 8,51 €
+  conséquence égal à
+    8,51 €
 ```
 
 ## Arrêté du 26 avril 2023 relatif au relèvement du salaire minimum de croissance
@@ -334,7 +362,8 @@ est porté à 11,52 € l'heure ;
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2023-05-01|
     et date_courante < |2024-01-01|
     et (
@@ -347,20 +376,23 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 11,52 €
+  conséquence égal à
+    11,52 €
 ```
 
 2° A Mayotte, son montant est fixé à 8,70 € l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2023-05-01|
     et date_courante < |2024-01-01|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 8,70 €
+  conséquence égal à
+    8,70 €
 ```
 
 ## Décret n° 2023-1216 du 20 décembre 2023 portant relèvement du salaire minimum de croissance
@@ -378,7 +410,8 @@ est porté à 11,65 euros l'heure ;
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2024-01-01|
     et (
       (résidence = Métropole)
@@ -390,17 +423,20 @@ champ d'application Smic:
       ou (résidence = SaintMartin)
       ou (résidence = SaintPierreEtMiquelon)
     )
-  conséquence égal à 11,65 €
+  conséquence égal à
+    11,65 €
 ```
 
 2° A Mayotte, son montant est fixé à 8,80 euros l'heure.
 
 ```catala
 champ d'application Smic:
-  définition brut_horaire sous condition
+  définition brut_horaire
+  sous condition
     date_courante >= |2024-01-01|
     et (
       (résidence = Mayotte)
     )
-  conséquence égal à 8,80 €
+  conséquence égal à
+    8,80 €
 ```

--- a/tests/fr/archives.catala_fr.result
+++ b/tests/fr/archives.catala_fr.result
@@ -9,7 +9,7 @@ habituellement au foyer :
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-09-01|:
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-09-01|:
   définition personnes_à_charge_prises_en_compte égal à
     liste de personne_à_charge parmi ménage.personnes_à_charge
       tel que prise_en_compte_personne_à_charge de personne_à_charge
@@ -21,14 +21,15 @@ l'article L. 823-2 du présent code ;
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-09-01|:
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-09-01|:
   # L'âge limite de 21 ans établi ici vient écraser la valeur de l'âge limite
   # prévue par L512-3 du CSS et définie par défaut par R512-2 du CSS.
   étiquette r823_4_enfants
   définition prestations_familiales.âge_l512_3_2 égal à 21 an
 
   étiquette r823_4_enfants
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     selon personne_à_charge sous forme
     -- EnfantÀCharge contenu enfant :
       # Pour être considéré à charge pour les aides personnelles au logement,
@@ -63,47 +64,49 @@ code ;
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  règle condition_2_r823_4 de personne_à_charge sous condition
+  règle condition_2_r823_4 de personne_à_charge
+  sous condition
     date_courante >= |2019-09-01|
     et date_courante < |2023-09-01|
     et selon personne_à_charge sous forme
-    -- EnfantÀCharge contenu enfant : faux
-    -- AutrePersonneÀCharge contenu parent :
-      parent.parenté = Ascendant
-      et parent.ressources
-      <= plafond_individuel_l815_9_sécu * 1,25
-      et (
-        # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
-        # à détecter
-        (
-          parent.date_naissance
-          + âge_l351_8_1_sécu
-          <= date_courante
-          ou (
-            parent.titulaire_allocation_personne_âgée
-            et (
-              résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
-                -- date_naissance: parent.date_naissance
-                -- date_courante: date_courante
-                -- années: 65 an
-              }
-            ).est_inférieur_ou_égal
+      -- EnfantÀCharge contenu enfant : faux
+      -- AutrePersonneÀCharge contenu parent :
+        parent.parenté = Ascendant
+        et parent.ressources
+        <= plafond_individuel_l815_9_sécu * 1,25
+        et (
+          # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
+          # à détecter
+          (
+            parent.date_naissance
+            + âge_l351_8_1_sécu
+            <= date_courante
+            ou (
+              parent.titulaire_allocation_personne_âgée
+              et (
+                  résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
+                    -- date_naissance: parent.date_naissance
+                    -- date_courante: date_courante
+                    -- années: 65 an
+                  }
+                ).est_inférieur_ou_égal
+            )
+          )
+          ou
+            # VERIF: parent.date_naissance + âge_l161_17_2_sécu est ambiguë,
+            # à détecter
+          (
+            parent.date_naissance
+            + âge_l161_17_2_sécu
+            <= date_courante
+            et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
           )
         )
-        ou
-        # VERIF: parent.date_naissance + âge_l161_17_2_sécu est ambiguë,
-        # à détecter
-        (
-          parent.date_naissance
-          + âge_l161_17_2_sécu
-          <= date_courante
-          et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
-        )
-      )
   conséquence rempli
 
   étiquette r823_4_2
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     # On utilise le si ... alors ... sinon pour éviter que l'appel de
     # la fonction "condition_2_r823_4" soit loggué deux fois lors
     # de l'évaluation des différentes justifications de l'arbre de défauts
@@ -127,9 +130,10 @@ au 31 décembre de l'année de référence multiplié par 1,25.
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-09-01|:
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-09-01|:
   exception r823_4_2
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     selon personne_à_charge sous forme
     -- EnfantÀCharge contenu enfant : faux
     -- AutrePersonneÀCharge contenu parent :
@@ -140,7 +144,7 @@ champ d'application ÉligibilitéAidesPersonnelleLogement
       )
       et parent.incapacité_80_pourcent_ou_restriction_emploi
       et parent.ressources
-      <= plafond_individuel_l815_9_sécu * 1,25
+        <= plafond_individuel_l815_9_sécu * 1,25
   conséquence rempli
 ```
 
@@ -177,11 +181,12 @@ compter du 1er octobre 2023.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
 
   # Colonne 1
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -192,7 +197,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonne 2
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -207,8 +213,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonnes 3 et 4
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -264,7 +270,8 @@ compter du 1er octobre 2023.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01|
+sous condition
+  date_courante >= |2023-10-01|
   et date_courante < |2024-10-01|
   et logement_est_chambre:
 
@@ -276,8 +283,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 234,74€
 
   exception chambre
-  définition plafond_loyer_d823_16_2 sous condition
-    âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
+  définition plafond_loyer_d823_16_2
+  sous condition âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
   conséquence égal à
     selon zone sous forme
     -- Zone1 : 239,48€
@@ -310,7 +317,7 @@ compter du 1er octobre 2023.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges_d823_16 égal à
@@ -329,11 +336,13 @@ défini au 2° de l'article D. 823-16 du même code et du forfait charge ou 37,9
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   définition participation_minimale égal à
-    si (loyer_éligible + montant_forfaitaire_charges_d823_16)
+    si
+      (loyer_éligible + montant_forfaitaire_charges_d823_16)
       * 8,5%
-      >= 37,91 € alors
+      >= 37,91 €
+    alors
       (loyer_éligible + montant_forfaitaire_charges_d823_16) * 8,5%
     sinon
       37,91 €
@@ -375,7 +384,7 @@ Majoration par personne à charge supplémentaire     -0,06 %
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   étiquette base
   définition taux_composition_familiale égal à
     si nombre_personnes_à_charge = 0 alors
@@ -412,7 +421,7 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   définition rapport_loyers égal à
     arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
 ```
@@ -435,7 +444,7 @@ $\textrm{TL}=0 \%$    $\textrm{TL}=0,45 \%\times (\textrm{RL}-45\%)$ $\textrm{TL
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   # Ici on choisit de mettre des >= pour inclure le résultat sur la crête
   # dans la case de droite ; nous avons bien vérifié que sur la crête le
   # résultat est le même à gauche et à droite.
@@ -472,7 +481,7 @@ Majoration par personne à charge	                    55,79
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
 
   étiquette base
   définition multiplicateur_majoration_loyer_référence égal à
@@ -518,14 +527,15 @@ charge supplémentaire               47,36  41,84  38,11
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01| et colocation:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01| et colocation:
 
   # Ici l'exception est rapportée au cas de base puisqu'on suppose
   # qu'on ne peut pas être en colocation dans un logement constitué
   # d'une seule chambre.
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -535,7 +545,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 195,62€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -545,8 +556,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 237,13€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -567,7 +578,7 @@ Majoration par personne à charge 13,17
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01| et colocation:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01| et colocation:
   étiquette colocation_métropole exception base_outre_mer
   définition montant_forfaitaire_charges_d823_16 égal à
     (
@@ -603,7 +614,7 @@ compter du 1er octobre 2023.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
 
   étiquette base
   définition montant_forfaitaire_charges_d832_10 égal à
@@ -618,7 +629,7 @@ Dans le cas des copropriétaires prévus à l'article D. 832-16 du même code :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   définition plafond_mensualité_d832_10_3
     état copropriétaires
   égal à
@@ -638,10 +649,10 @@ Majoration par personne à charge 13,17
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   exception base
-  définition montant_forfaitaire_charges_d832_10 sous condition
-    copropriété
+  définition montant_forfaitaire_charges_d832_10
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -680,98 +691,98 @@ compter du 1er octobre 2023.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   définition plafond_équivalence_loyer_éligible égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 478,09 €
-              -- Couple : 560,47€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                597,62 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    639,57 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        681,67 €
-                      sinon
-                        (
-                          735,25 €
-                          + 76,26€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 437,20 €
-              -- Couple : 510,24€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                544,05 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    582,37 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        620,55 €
-                      sinon
-                        (
-                          661,23 €
-                          + 68,92€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 414,99 €
-              -- Couple : 482,66€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                512,07 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    545,86 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        579,64 €
-                      sinon
-                        (
-                          617,64 €
-                          + 63,96€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 478,09 €
+            -- Couple : 560,47€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              597,62 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  639,57 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      681,67 €
+                    sinon
+                      (
+                        735,25 €
+                        + 76,26€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 437,20 €
+            -- Couple : 510,24€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              544,05 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  582,37 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      620,55 €
+                    sinon
+                      (
+                        661,23 €
+                        + 68,92€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 414,99 €
+            -- Couple : 482,66€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              512,07 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  545,86 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      579,64 €
+                    sinon
+                      (
+                        617,64 €
+                        + 63,96€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+  )
 ```
 
 ### Article 34 | LEGIARTI000048109284 [archive]
@@ -792,7 +803,7 @@ compter du 1er octobre 2023.
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges égal à
@@ -812,12 +823,11 @@ Dans le cas des copropriétaires prévus à l'article D. 842-10 du même code :
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_copropriété
-  sous condition
-    copropriété
+  sous condition copropriété
   conséquence égal à
     (
       calcul_plafond_mensualité_d842_6 de
@@ -837,10 +847,10 @@ Majoration par personne à charge                         13,17
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
   étiquette copropriété exception base
-  définition montant_forfaitaire_charges sous condition
-    copropriété
+  définition montant_forfaitaire_charges
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -874,7 +884,7 @@ compter du 1er octobre 2023.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges égal à
@@ -899,9 +909,9 @@ b) 140,34 euros euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 90,13 €
@@ -916,9 +926,9 @@ b) 283,23 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 182,23 €
@@ -933,9 +943,9 @@ b) 343,58 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 221,10 €
@@ -950,9 +960,9 @@ b) 283,23 euros lorsqu'il s'agit d'un couple.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
+sous condition date_courante >= |2023-10-01| et date_courante < |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 182,23 €
@@ -985,9 +995,10 @@ enfant à charge, est remplacée par " 8 574 euros " ;
 # locatif. Notamment le paramètre R0 est défini dans le calcul des APL,
 # pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1024,53 +1035,53 @@ Par personne supplémentaire à charge                10,36
 # locatif. Notamment le paramètre du montant des charges est défini dans le
 # calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     40,26€ + 10,36€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     40,26 € + 10,36 € * multiplicateur_majoration_charges
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     40,26 € + 10,36 € * multiplicateur_majoration_charges
 ```
@@ -1094,9 +1105,10 @@ Majoration par personne à charge 10,36
 # locatif. Notamment le paramètre du montant des charges colocation est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
+  définition montant_forfaitaire_charges_d823_16
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1117,9 +1129,10 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     + 10,36€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
+  définition montant_forfaitaire_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1182,19 +1195,19 @@ Majoration par personne à charge supplémentaire     -0,06 %
 # locatif. Notamment le paramètre TF est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-10-01| et date_courante < |2025-01-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -1256,7 +1269,7 @@ Personne seule ou couple ayant :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-01-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2025-01-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_r0 égal à
@@ -1310,9 +1323,10 @@ enfant à charge, est remplacée par " 8 574 euros " ;
 # locatif. Notamment le paramètre R0 est défini dans le calcul des APL,
 # pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1349,53 +1363,53 @@ Par personne supplémentaire à charge                10,03
 # locatif. Notamment le paramètre du montant des charges est défini dans le
 # calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     38,99€ + 10,03€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     38,99 € + 10,03 € * multiplicateur_majoration_charges
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     38,99 € + 10,03 € * multiplicateur_majoration_charges
 ```
@@ -1419,9 +1433,10 @@ Majoration par personne à charge 10,03
 # locatif. Notamment le paramètre du montant des charges colocation est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
+  définition montant_forfaitaire_charges_d823_16
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1442,9 +1457,10 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     + 10,03€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
+  définition montant_forfaitaire_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1507,19 +1523,19 @@ Majoration par personne à charge supplémentaire     -0,06 %
 # locatif. Notamment le paramètre TF est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2024-10-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -1602,9 +1618,10 @@ ces dispositions sont applicables aux prestations dues à compter du 1er janvier
 # locatif. Notamment le paramètre RO est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-01-01| et date_courante < |2025-01-01|:
+sous condition date_courante >= |2024-01-01| et date_courante < |2025-01-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     selon résidence sous forme
     -- SaintPierreEtMiquelon : vrai
     -- n'importe quel : faux
@@ -1651,9 +1668,10 @@ enfant à charge, est remplacée par " 8 181 euros " ;
 # locatif. Notamment le paramètre R0 est défini dans le calcul des APL,
 # pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
+sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1690,53 +1708,53 @@ Par personne supplémentaire à charge                10,03
 # locatif. Notamment le paramètre du montant des charges est défini dans le
 # calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
+sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     38,99€ + 10,03€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01|:
+sous condition date_courante >= |2023-10-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     38,99 € + 10,03 € * multiplicateur_majoration_charges
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
+sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     38,99 € + 10,03 € * multiplicateur_majoration_charges
 ```
@@ -1760,9 +1778,10 @@ Majoration par personne à charge 10,03
 # locatif. Notamment le paramètre du montant des charges colocation est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
+sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
+  définition montant_forfaitaire_charges_d823_16
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1783,9 +1802,10 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     + 10,03€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-10-01|:
+sous condition date_courante >= |2023-10-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
+  définition montant_forfaitaire_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1848,19 +1868,19 @@ Majoration par personne à charge supplémentaire     -0,06 %
 # locatif. Notamment le paramètre TF est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
+sous condition date_courante >= |2023-10-01| et date_courante <= |2023-12-31|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -1921,9 +1941,10 @@ enfant à charge, est remplacée par " 8 181 euros " ;
 # locatif. Notamment le paramètre R0 est défini dans le calcul des APL,
 # pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -1960,53 +1981,53 @@ Par personne supplémentaire à charge                9,69
 # locatif. Notamment le paramètre du montant des charges est défini dans le
 # calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     37,67€ + 9,69€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     37,67 € + 9,69 € * multiplicateur_majoration_charges
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     37,67 € + 9,69 € * multiplicateur_majoration_charges
 ```
@@ -2030,9 +2051,10 @@ Majoration par personne à charge 9,69
 # locatif. Notamment le paramètre du montant des charges colocation est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
+  définition montant_forfaitaire_charges_d823_16
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -2053,9 +2075,10 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     + 9,69€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
+  définition montant_forfaitaire_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -2118,19 +2141,19 @@ Majoration par personne à charge supplémentaire     -0,06 %
 # locatif. Notamment le paramètre TF est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2023-01-01| et date_courante < |2023-10-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -2219,11 +2242,12 @@ ces dispositions sont applicables pour les prestations dues à compter du 1er ju
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
 
   # Colonne 1
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -2234,7 +2258,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonne 2
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -2249,8 +2274,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonnes 3 et 4
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -2305,7 +2330,8 @@ ces dispositions sont applicables pour les prestations dues à compter du 1er ju
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01|
+sous condition
+  date_courante >= |2022-07-01|
   et date_courante < |2023-10-01|
   et logement_est_chambre:
 
@@ -2317,8 +2343,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 226,80€
 
   exception chambre
-  définition plafond_loyer_d823_16_2 sous condition
-    âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
+  définition plafond_loyer_d823_16_2
+  sous condition âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
   conséquence égal à
     selon zone sous forme
     -- Zone1 : 231,38€
@@ -2351,7 +2377,7 @@ ces dispositions sont applicables pour les prestations dues à compter du
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges_d823_16 égal à
@@ -2370,11 +2396,13 @@ défini au 2° de l'article D. 823-16 du même code et du forfait charge ou 36,6
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   définition participation_minimale égal à
-    si (loyer_éligible + montant_forfaitaire_charges_d823_16)
+    si
+      (loyer_éligible + montant_forfaitaire_charges_d823_16)
       * 8,5%
-      >= 36,63 € alors
+      >= 36,63 €
+    alors
       (loyer_éligible + montant_forfaitaire_charges_d823_16) * 8,5%
     sinon
       36,63 €
@@ -2416,7 +2444,7 @@ Majoration par personne à charge supplémentaire     -0,06 %
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   étiquette base
   définition taux_composition_familiale égal à
     si nombre_personnes_à_charge = 0 alors
@@ -2453,7 +2481,7 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   définition rapport_loyers égal à
     arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
 ```
@@ -2476,7 +2504,7 @@ $\textrm{TL}=0 \%$    $\textrm{TL}=0,45 \%\times (\textrm{RL}-45\%)$ $\textrm{TL
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   # Ici on choisit de mettre des >= pour inclure le résultat sur la crête
   # dans la case de droite ; nous avons bien vérifié que sur la crête le
   # résultat est le même à gauche et à droite.
@@ -2513,7 +2541,7 @@ Majoration par personne à charge	                    53,90
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
 
   étiquette base
   définition multiplicateur_majoration_loyer_référence égal à
@@ -2553,7 +2581,8 @@ Personne seule ou couple ayant :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01|
+sous condition
+  date_courante >= |2022-07-01|
   et date_courante <= |2022-12-31|:
 
   étiquette métropole
@@ -2613,7 +2642,8 @@ charge supplémentaire               45,76  40,43  36,82
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01|
+sous condition
+  date_courante >= |2022-07-01|
   et date_courante < |2023-10-01|
   et colocation:
 
@@ -2622,7 +2652,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
   # d'une seule chambre.
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -2632,7 +2663,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 189,00€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -2642,8 +2674,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 229,11€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -2664,7 +2696,8 @@ Majoration par personne à charge 12,72
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01|
+sous condition
+  date_courante >= |2022-07-01|
   et date_courante < |2023-10-01|
   et colocation:
   étiquette colocation_métropole exception base_outre_mer
@@ -2702,7 +2735,7 @@ juillet 2022.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
 
   étiquette base
   définition montant_forfaitaire_charges_d832_10 égal à
@@ -2717,7 +2750,7 @@ Dans le cas des copropriétaires prévus à l'article D. 832-16 du même code :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   définition plafond_mensualité_d832_10_3
     état copropriétaires
   égal à
@@ -2737,10 +2770,10 @@ Majoration par personne à charge 12,72
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   exception base
-  définition montant_forfaitaire_charges_d832_10 sous condition
-    copropriété
+  définition montant_forfaitaire_charges_d832_10
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -2780,98 +2813,98 @@ dispositions sont applicables pour les prestations dues à compter du
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   définition plafond_équivalence_loyer_éligible égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 461,92 €
-              -- Couple : 541,52€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                577,41 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    617,94 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        658,62 €
-                      sinon
-                        (
-                          710,39 €
-                          + 73,68€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 422,42 €
-              -- Couple : 492,99€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                525,65 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    562,68 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        599,57 €
-                      sinon
-                        (
-                          638,87 €
-                          + 66,59€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 400,96 €
-              -- Couple : 466,34€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                494,75 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    527,40 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        560,04 €
-                      sinon
-                        (
-                          596,75 €
-                          + 61,80€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 461,92 €
+            -- Couple : 541,52€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              577,41 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  617,94 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      658,62 €
+                    sinon
+                      (
+                        710,39 €
+                        + 73,68€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 422,42 €
+            -- Couple : 492,99€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              525,65 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  562,68 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      599,57 €
+                    sinon
+                      (
+                        638,87 €
+                        + 66,59€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 400,96 €
+            -- Couple : 466,34€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              494,75 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  527,40 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      560,04 €
+                    sinon
+                      (
+                        596,75 €
+                        + 61,80€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+  )
 ```
 
 ### Article 34 | LEGIARTI000046206196 [archive]
@@ -2892,7 +2925,7 @@ juillet 2022.
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges égal à
@@ -2912,12 +2945,11 @@ Dans le cas des copropriétaires prévus à l'article D. 842-10 du même code :
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_copropriété
-  sous condition
-    copropriété
+  sous condition copropriété
   conséquence égal à
     (
       calcul_plafond_mensualité_d842_6 de
@@ -2937,10 +2969,10 @@ Majoration par personne à charge                         12,72
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
   étiquette copropriété exception base
-  définition montant_forfaitaire_charges sous condition
-    copropriété
+  définition montant_forfaitaire_charges
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -2974,7 +3006,7 @@ juillet 2022.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges égal à
@@ -2999,9 +3031,9 @@ b) 135,59 euros euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 87,08 €
@@ -3016,9 +3048,9 @@ b) 273,65 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 176,07 €
@@ -3033,9 +3065,9 @@ b) 331,96 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 213,62 €
@@ -3050,9 +3082,9 @@ b) 273,65 euros lorsqu'il s'agit d'un couple.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 176,07 €
@@ -3078,9 +3110,10 @@ construction et de l'habitation, dont les valeurs sont fixées à l'article 7 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception métropole
-  définition multiplicateur_majoration_plafond_loyer_d823_16_2 sous condition
+  définition multiplicateur_majoration_plafond_loyer_d823_16_2
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3092,7 +3125,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 # Cette limitation à 6 personnes à charge s'applique également aux exceptions à
 # l'article 7 que sont les articles 8 et 16 de l'arrêté pour les chambres et la
 # colocation. Cependant le barème chambre ne dépend pas du nombre de personnes à
@@ -3128,9 +3162,10 @@ valeurs sont fixées respectivement aux articles 9, 34 et 40 ;
 # au 3° de cet article.
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3142,12 +3177,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3159,7 +3196,8 @@ champ d'application CalculAllocationLogementFoyer
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 ```
 
 c) Le loyer de référence " LR ", dont les valeurs sont fixées à l'article 14,
@@ -3168,9 +3206,10 @@ personnelle (" Tp ") visé au 3° de l'article D. 823-17 du même code ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception base
-  définition multiplicateur_majoration_loyer_référence sous condition
+  définition multiplicateur_majoration_loyer_référence
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3182,7 +3221,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 ```
 
 d) Le forfait " R0 ", visé au 5° de l'article D. 823-17 du même code, dont
@@ -3190,9 +3230,10 @@ les valeurs sont fixées à l'article 15 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception métropole
-  définition multiplicateur_majoration_r0 sous condition
+  définition multiplicateur_majoration_r0
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3204,7 +3245,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 0,0
+  conséquence égal à
+    0,0
 ```
 
 e) Les mensualités plafonds visées à l'article D. 842-6 du même code, dont les
@@ -3212,20 +3254,20 @@ valeurs sont fixées à l'article 33 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_limitation_dom_tom
   sous condition
     nombre_personnes_à_charge >= 6
     et selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
   conséquence égal à
     calcul_plafond_mensualité_d842_6 de date_calcul, 6
 ```
@@ -3235,9 +3277,10 @@ un ménage ayant un enfant à charge, est remplacée par " 8 051 euros " ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3265,19 +3308,19 @@ Par personne supplémentaire à charge dans la limite de six personnes à charge
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       37,67€ + 9,69€ * (décimal de nombre_personnes_à_charge)
@@ -3288,19 +3331,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       37,67€ + 9,69€ * (décimal de nombre_personnes_à_charge)
@@ -3311,19 +3354,19 @@ champ d'application CalculAllocationLogementAccessionPropriété
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       37,67€ + 9,69€ * (décimal de nombre_personnes_à_charge)
@@ -3346,19 +3389,19 @@ Majoration par personne à charge dans la limite de six personnes à charge 9,69
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -3379,19 +3422,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -3430,19 +3473,19 @@ Personne seule ou couple ayant 6 personnes à charge et plus 1,62 %
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -3507,9 +3550,10 @@ sont applicables pour les prestations dues à compter du 1 er juillet 2022.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
+sous condition date_courante >= |2022-07-01| et date_courante < |2023-01-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     selon résidence sous forme
     -- SaintPierreEtMiquelon : vrai
     -- n'importe quel : faux
@@ -3556,7 +3600,7 @@ Personne seule ou couple ayant :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-01-01| et date_courante <= |2023-12-31|:
+sous condition date_courante >= |2023-01-01| et date_courante <= |2023-12-31|:
 
   étiquette métropole
   définition multiplicateur_majoration_r0 égal à
@@ -3633,9 +3677,10 @@ dues à compter du 1er janvier 2023.
 # locatif. Notamment le paramètre RO est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-01-01| et date_courante <= |2023-12-31|:
+sous condition date_courante >= |2023-01-01| et date_courante <= |2023-12-31|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     selon résidence sous forme
     -- SaintPierreEtMiquelon : vrai
     -- n'importe quel : faux
@@ -3704,7 +3749,8 @@ Personne seule ou couple ayant :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01|
+sous condition
+  date_courante >= |2022-01-01|
   et date_courante < |2022-07-01|:
 
   étiquette métropole
@@ -3749,9 +3795,10 @@ dont les valeurs sont fixées à l'article 7 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception métropole
-  définition multiplicateur_majoration_plafond_loyer_d823_16_2 sous condition
+  définition multiplicateur_majoration_plafond_loyer_d823_16_2
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3763,7 +3810,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 # Cette limitation à 6 personnes à charge s'applique également aux exceptions à
 # l'article 7 que sont les articles 8 et 16 de l'arrêté pour les chambres et la
 # colocation. Cependant le barème chambre ne dépend pas du nombre de personnes à
@@ -3798,9 +3846,10 @@ D. 842-6 et D. 842-15 du même code, dont les valeurs sont fixées respectivemen
 # au 3° de cet article.
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3812,12 +3861,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3829,7 +3880,8 @@ champ d'application CalculAllocationLogementFoyer
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 ```
 
 c) Le loyer de référence " LR ", dont les valeurs sont fixées à l'article 14, intervenant dans le calcul de
@@ -3838,9 +3890,10 @@ code ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception base
-  définition multiplicateur_majoration_loyer_référence sous condition
+  définition multiplicateur_majoration_loyer_référence
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3852,7 +3905,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 ```
 
 d) Le forfait " R0 ", visé au 5° de l'article D. 823-17 du même code, dont les valeurs sont fixées à
@@ -3860,10 +3914,11 @@ l'article 15 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
 
   exception métropole
-  définition multiplicateur_majoration_r0 sous condition
+  définition multiplicateur_majoration_r0
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3875,7 +3930,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 0,0
+  conséquence égal à
+    0,0
 ```
 
 e) Les mensualités plafonds visées à l'article D. 842-6 du même code, dont les valeurs sont fixées à
@@ -3883,20 +3939,20 @@ l'article 33 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_limitation_dom_tom
   sous condition
     nombre_personnes_à_charge >= 6
     et selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
   conséquence égal à
     calcul_plafond_mensualité_d842_6 de date_calcul, 6
 ```
@@ -3906,9 +3962,10 @@ un ménage ayant un enfant à charge, est remplacée par " 7 742 euros " ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -3936,19 +3993,19 @@ Par personne supplémentaire à charge dans la limite de six personnes à charge
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,40€ + 9,36€ * (décimal de nombre_personnes_à_charge)
@@ -3959,19 +4016,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,40€ + 9,36€ * (décimal de nombre_personnes_à_charge)
@@ -3982,19 +4039,19 @@ champ d'application CalculAllocationLogementAccessionPropriété
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,40€ + 9,36€ * (décimal de nombre_personnes_à_charge)
@@ -4017,19 +4074,19 @@ Majoration par personne à charge dans la limite de six personnes à charge 9,36
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -4050,19 +4107,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -4101,19 +4158,19 @@ Couple sans enfant                 2,99%
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
+sous condition date_courante >= |2022-01-01| et date_courante < |2022-07-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -4195,12 +4252,14 @@ pour les prestations dues à compter du 1er octobre 2021.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
 
   # Colonne 1
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -4211,7 +4270,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonne 2
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -4226,8 +4286,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonnes 3 et 4
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4283,7 +4343,8 @@ compter du 1er octobre 2021.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|
   et logement_est_chambre:
 
@@ -4295,8 +4356,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 219,13€
 
   exception chambre
-  définition plafond_loyer_d823_16_2 sous condition
-    âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
+  définition plafond_loyer_d823_16_2
+  sous condition âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
   conséquence égal à
     selon zone sous forme
     -- Zone1 : 223,55€
@@ -4329,7 +4390,8 @@ du 1er octobre 2021.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
 
   étiquette métropole
@@ -4349,12 +4411,15 @@ défini au 2° de l'article D. 823-16 du même code et du forfait charge ou 35,3
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   définition participation_minimale égal à
-    si (loyer_éligible + montant_forfaitaire_charges_d823_16)
+    si
+      (loyer_éligible + montant_forfaitaire_charges_d823_16)
       * 8,5%
-      >= 35,39 € alors
+      >= 35,39 €
+    alors
       (loyer_éligible + montant_forfaitaire_charges_d823_16) * 8,5%
     sinon
       35,39 €
@@ -4392,7 +4457,8 @@ Majoration par personne à charge                    -0,06%
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   étiquette base
   définition taux_composition_familiale égal à
@@ -4423,7 +4489,8 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   définition rapport_loyers égal à
     arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
@@ -4447,7 +4514,8 @@ $\textrm{TL}=0 \%$    $\textrm{TL}=0,45 \%\times (\textrm{RL}-45\%)$ $\textrm{TL
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   # Ici on choisit de mettre des >= pour inclure le résultat sur la crête
   # dans la case de droite ; nous avons bien vérifié que sur la crête le
@@ -4485,7 +4553,8 @@ Majoration par personne à charge	                    52,08
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
 
   étiquette base
@@ -4530,7 +4599,8 @@ charge supplémentaire               44,21  39,06  35,57
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01| et colocation:
 
   # Ici l'exception est rapportée au cas de base puisqu'on suppose
@@ -4538,7 +4608,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
   # d'une seule chambre.
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -4548,7 +4619,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 182,61€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -4562,8 +4634,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     décimal de (nombre_personnes_à_charge - 1)
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4584,7 +4656,8 @@ Majoration par personne à charge 12,29
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01| et colocation:
   étiquette colocation_métropole exception base_outre_mer
   définition montant_forfaitaire_charges_d823_16 égal à
@@ -4619,7 +4692,8 @@ du 1er octobre 2021.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
 
   étiquette base
@@ -4635,7 +4709,8 @@ Dans le cas des copropriétaires prévus à l'article D. 832-16 du même code :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   définition plafond_mensualité_d832_10_3
     état copropriétaires
@@ -4656,11 +4731,12 @@ Majoration par personne à charge 12,29
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   exception base
-  définition montant_forfaitaire_charges_d832_10 sous condition
-    copropriété
+  définition montant_forfaitaire_charges_d832_10
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -4695,7 +4771,8 @@ pour les prestations dues à compter du 1er octobre 2021.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   définition plafond_équivalence_loyer_éligible égal à
     selon zone sous forme
@@ -4768,7 +4845,8 @@ les prestations dues à compter du 1er octobre 2021.
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
 
   étiquette métropole
@@ -4789,13 +4867,13 @@ Dans le cas des copropriétaires prévus à l'article D. 842-10 du même code :
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_copropriété
-  sous condition
-    copropriété
+  sous condition copropriété
   conséquence égal à
     (
       calcul_plafond_mensualité_d842_6 de
@@ -4815,11 +4893,12 @@ Majoration par personne à charge                         12,29
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
   étiquette copropriété exception base
-  définition montant_forfaitaire_charges sous condition
-    copropriété
+  définition montant_forfaitaire_charges
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -4855,7 +4934,8 @@ sont applicables pour les prestations dues à compter du 1er octobre 2021.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
 
   étiquette métropole
@@ -4881,10 +4961,11 @@ b) 131,00 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 84,14 €
@@ -4899,10 +4980,11 @@ b) 264,40 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 170,12 €
@@ -4917,10 +4999,11 @@ b) 320,73 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 206,40 €
@@ -4935,10 +5018,11 @@ b) 264,40 euros lorsqu'il s'agit d'un couple.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2021-10-01|
+sous condition
+  date_courante >= |2021-10-01|
   et date_courante < |2022-07-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 170,12 €
@@ -4961,9 +5045,10 @@ dont les valeurs sont fixées à l'article 7 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception métropole
-  définition multiplicateur_majoration_plafond_loyer_d823_16_2 sous condition
+  définition multiplicateur_majoration_plafond_loyer_d823_16_2
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -4975,7 +5060,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 # Cette limitation à 6 personnes à charge s'applique également aux exceptions à
 # l'article 7 que sont les articles 8 et 16 de l'arrêté pour les chambres et la
 # colocation. Cependant le barème chambre ne dépend pas du nombre de personnes à
@@ -5010,9 +5096,10 @@ D. 842-6 et D. 842-15 du même code, dont les valeurs sont fixées respectivemen
 # au 3° de cet article.
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5024,12 +5111,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5041,7 +5130,8 @@ champ d'application CalculAllocationLogementFoyer
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 ```
 
 c) Le loyer de référence " LR ", dont les valeurs sont fixées à l'article 14, intervenant dans le calcul
@@ -5050,9 +5140,10 @@ code ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception base
-  définition multiplicateur_majoration_loyer_référence sous condition
+  définition multiplicateur_majoration_loyer_référence
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5064,7 +5155,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 ```
 
 d) Le forfait " R0 ", visé au 5° de l'article D. 823-17 du même code, dont les valeurs sont fixées à
@@ -5072,9 +5164,10 @@ l'article 15 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception métropole
-  définition multiplicateur_majoration_r0 sous condition
+  définition multiplicateur_majoration_r0
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5086,7 +5179,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 0,0
+  conséquence égal à
+    0,0
 ```
 
 e) Les mensualités plafonds visées à l'article D. 842-6 du même code, dont les valeurs sont fixées à
@@ -5094,20 +5188,20 @@ l'article 33 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_limitation_dom_tom
   sous condition
     nombre_personnes_à_charge >= 6
     et selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
   conséquence égal à
     calcul_plafond_mensualité_d842_6 de date_calcul, 6
 ```
@@ -5117,9 +5211,10 @@ pour un ménage ayant un enfant à charge, est remplacée par " 7 584 euros " ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   étiquette article_46 exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5147,19 +5242,19 @@ Par personne supplémentaire à charge dans la limite de six personnes à charge
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,40€ + 9,36€ * (décimal de nombre_personnes_à_charge)
@@ -5170,19 +5265,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,40€ + 9,36€ * (décimal de nombre_personnes_à_charge)
@@ -5193,19 +5288,19 @@ champ d'application CalculAllocationLogementAccessionPropriété
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,40€ + 9,36€ * (décimal de nombre_personnes_à_charge)
@@ -5228,19 +5323,19 @@ Majoration par personne à charge dans la limite de six personnes à charge  9,3
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -5261,19 +5356,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -5311,19 +5406,19 @@ Couple sans enfant                2,99%
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-10-01| et date_courante < |2022-01-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -5374,12 +5469,14 @@ octobre 2020.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01|:
 
   # Colonne 1
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -5390,7 +5487,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonne 2
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -5405,8 +5503,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonnes 3 et 4
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -5461,7 +5559,8 @@ sont applicables pour les prestations dues à compter du 1er octobre 2020.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01|
   et logement_est_chambre:
 
@@ -5473,8 +5572,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 218,21€
 
   exception chambre
-  définition plafond_loyer_d823_16_2 sous condition
-    âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
+  définition plafond_loyer_d823_16_2
+  sous condition âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
   conséquence égal à
     selon zone sous forme
     -- Zone1 : 222,62€
@@ -5507,7 +5606,8 @@ compter du 1er octobre 2020.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01|:
 
   étiquette métropole
@@ -5527,12 +5627,15 @@ défini au 2° de l'article D. 823-16 du même code et du forfait charge ou 35,2
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01|:
   définition participation_minimale égal à
-    si (loyer_éligible + montant_forfaitaire_charges_d823_16)
+    si
+      (loyer_éligible + montant_forfaitaire_charges_d823_16)
       * 8,5%
-      >= 35,24 € alors
+      >= 35,24 €
+    alors
       (loyer_éligible + montant_forfaitaire_charges_d823_16) * 8,5%
     sinon
       35,24 €
@@ -5571,7 +5674,8 @@ Majoration par personne à charge	                   -0,06%
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   étiquette base
   définition taux_composition_familiale égal à
@@ -5602,7 +5706,8 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   définition rapport_loyers égal à
     arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
@@ -5626,7 +5731,8 @@ $\text{TL}=0 \%$    $\text{TL}=0,45 \%\times (\text{RL}-45\%)$ $\text{TL}=0,45\%
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   définition taux_loyer_éligible
     état formule
@@ -5661,7 +5767,8 @@ Majoration par personne à charge	                    51,86
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
 
   étiquette base
@@ -5708,11 +5815,13 @@ charge supplémentaire              44,03  38,90  35,42
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01| et colocation:
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -5722,7 +5831,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 181,85€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -5736,8 +5846,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     décimal de (nombre_personnes_à_charge - 1)
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -5758,7 +5868,8 @@ Majoration par personne à charge 12,24
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01| et colocation:
   étiquette colocation_métropole exception base_outre_mer
   définition montant_forfaitaire_charges_d823_16 égal à
@@ -5794,7 +5905,8 @@ sont applicables pour les prestations dues à compter du 1er octobre 2020.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01|:
 
   étiquette base
@@ -5810,7 +5922,8 @@ Dans le cas des copropriétaires prévus à l'article D. 832-16 du même code :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01|:
   définition plafond_mensualité_d832_10_3
     état copropriétaires
@@ -5831,11 +5944,12 @@ Majoration par personne à charge 12,24
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante < |2021-10-01|
+sous condition
+  date_courante < |2021-10-01|
   et date_courante >= |2020-10-01|:
   exception base
-  définition montant_forfaitaire_charges_d832_10 sous condition
-    copropriété
+  définition montant_forfaitaire_charges_d832_10
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -5871,7 +5985,7 @@ sont applicables pour les prestations dues à compter du 1er octobre 2020.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante < |2021-10-01| et date_courante >= |2020-10-01|:
+sous condition date_courante < |2021-10-01| et date_courante >= |2020-10-01|:
   définition plafond_équivalence_loyer_éligible égal à
     selon zone sous forme
     -- Zone1 :
@@ -5942,7 +6056,8 @@ applicables pour les prestations dues à compter du 1er octobre 2020.
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   étiquette base
   définition montant_forfaitaire_charges égal à
@@ -5966,13 +6081,13 @@ l'article 33 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_copropriété
-  sous condition
-    copropriété
+  sous condition copropriété
   conséquence égal à
     (
       calcul_plafond_mensualité_d842_6 de
@@ -5992,11 +6107,12 @@ Majoration par personne à charge  12,24
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   étiquette copropriété exception base
-  définition montant_forfaitaire_charges sous condition
-    copropriété
+  définition montant_forfaitaire_charges
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -6026,7 +6142,8 @@ Par personne supplémentaire à charge                12,24
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
   étiquette base
   définition montant_forfaitaire_charges égal à
@@ -6057,10 +6174,11 @@ b) 130,45 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 83,79 €
@@ -6075,10 +6193,11 @@ b) 263,29 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 169,41 €
@@ -6093,10 +6212,11 @@ b) 319,39 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 205,54 €
@@ -6111,10 +6231,11 @@ b) 263,29 euros lorsqu'il s'agit d'un couple.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-10-01|
+sous condition
+  date_courante >= |2020-10-01|
   et date_courante < |2021-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 169,41 €
@@ -6138,9 +6259,10 @@ l'habitation , dont les valeurs sont fixées à l'article 7 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception métropole
-  définition multiplicateur_majoration_plafond_loyer_d823_16_2 sous condition
+  définition multiplicateur_majoration_plafond_loyer_d823_16_2
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6152,7 +6274,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 # Cette limitation à 6 personnes à charge s'applique également aux exceptions à
 # l'article 7 que sont les articles 8 et 16 de l'arrêté pour les chambres et la
 # colocation. Cependant le barème chambre ne dépend pas du nombre de personnes à
@@ -6188,9 +6311,10 @@ articles 9, 34 et 40 ;
 # au 3° de cet article.
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6202,12 +6326,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6219,7 +6345,8 @@ champ d'application CalculAllocationLogementFoyer
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 ```
 
 c) Le loyer de référence " LR ", dont les valeurs sont fixées à l'article 14, intervenant dans
@@ -6228,9 +6355,10 @@ D. 823-17 du même code ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception base
-  définition multiplicateur_majoration_loyer_référence sous condition
+  définition multiplicateur_majoration_loyer_référence
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6242,7 +6370,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 ```
 
 d) Le forfait " R0 ", visé au 5° de l'article D. 823-17 du même code, dont les valeurs sont
@@ -6250,9 +6379,10 @@ fixées à l'article 15 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception métropole
-  définition multiplicateur_majoration_r0 sous condition
+  définition multiplicateur_majoration_r0
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6264,7 +6394,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 0,0
+  conséquence égal à
+    0,0
 ```
 
 e) Les mensualités plafonds visées à l'article D. 842-6 du même code, dont les valeurs sont
@@ -6272,20 +6403,20 @@ fixées à l'article 33 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_limitation_dom_tom
   sous condition
     nombre_personnes_à_charge >= 6
     et selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
   conséquence égal à
     calcul_plafond_mensualité_d842_6 de date_calcul, 6
 ```
@@ -6295,9 +6426,10 @@ code, pour un ménage ayant un enfant à charge, est remplacée par " 7 584 euro
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   étiquette article_46 exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6326,19 +6458,19 @@ Par personne supplémentaire à charge dans la limite de six personnes à charge
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,25€ + 9,32€ * (décimal de nombre_personnes_à_charge)
@@ -6349,19 +6481,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,25€ + 9,32€ * (décimal de nombre_personnes_à_charge)
@@ -6372,19 +6504,19 @@ champ d'application CalculAllocationLogementAccessionPropriété
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,25€ + 9,32€ * (décimal de nombre_personnes_à_charge)
@@ -6407,19 +6539,19 @@ Majoration par personne à charge dans la limite de six personnes à charge   9,
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -6440,19 +6572,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -6491,19 +6623,19 @@ Couple sans enfant                2,99%
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
+sous condition date_courante >= |2020-10-01| et date_courante < |2021-10-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -6615,18 +6747,18 @@ Personne seule ou couple ayant :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2021-01-01| et date_courante < |2022-01-01|:
+sous condition date_courante >= |2021-01-01| et date_courante < |2022-01-01|:
   exception article_46
-  # Normalement la règle suivante aurait du être une exception à l'étiquette
-  # "métropole". Cependant, la version de l'article 46 de l'arrêté du 27
-  # septembre 2019 en vigueur du 1er janvier 2020 au 31 décembre 2020 prévoit
-  # également dans le cas de l'outre-mer un remplacement du de la valeur de R0
-  # de l'article 15 dans le cas de une personne à charge. Pour faire exister
-  # cette règle plus précise valable uniquement pour Mayotte, nous la codons ici
-  # comme une exception au tableau de l'article 46 afin d'éviter le conflit
-  # entre deux règles qui s'activent en même temps.
-  définition abattement_forfaitaire_d823_17 sous condition
-    résidence sous forme Mayotte
+    # Normalement la règle suivante aurait du être une exception à l'étiquette
+    # "métropole". Cependant, la version de l'article 46 de l'arrêté du 27
+    # septembre 2019 en vigueur du 1er janvier 2020 au 31 décembre 2020 prévoit
+    # également dans le cas de l'outre-mer un remplacement du de la valeur de R0
+    # de l'article 15 dans le cas de une personne à charge. Pour faire exister
+    # cette règle plus précise valable uniquement pour Mayotte, nous la codons ici
+    # comme une exception au tableau de l'article 46 afin d'éviter le conflit
+    # entre deux règles qui s'activent en même temps.
+  définition abattement_forfaitaire_d823_17
+  sous condition résidence sous forme Mayotte
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -6672,7 +6804,8 @@ Personne seule ou couple ayant :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante < |2022-01-01|
+sous condition
+  date_courante < |2022-01-01|
   et date_courante >= |2020-01-01|:
 
   étiquette métropole
@@ -6730,9 +6863,10 @@ de l'habitation , dont les valeurs sont fixées à l'article 7 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception métropole
-  définition multiplicateur_majoration_plafond_loyer_d823_16_2 sous condition
+  définition multiplicateur_majoration_plafond_loyer_d823_16_2
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6744,7 +6878,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 # Cette limitation à 6 personnes à charge s'applique également aux exceptions à
 # l'article 7 que sont les articles 8 et 16 de l'arrêté pour les chambres et la
 # colocation. Cependant le barème chambre ne dépend pas du nombre de personnes à
@@ -6780,9 +6915,10 @@ aux articles 9, 34 et 40 ;
 # au 3° de cet article.
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6794,12 +6930,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception métropole
-  définition multiplicateur_majoration_charges sous condition
+  définition multiplicateur_majoration_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6811,7 +6949,8 @@ champ d'application CalculAllocationLogementFoyer
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 6,0
+  conséquence égal à
+    6,0
 ```
 
 c) Le loyer de référence " LR ", dont les valeurs sont fixées à l'article 14, intervenant
@@ -6820,9 +6959,10 @@ de l'article D. 823-17 du même code ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception base
-  définition multiplicateur_majoration_loyer_référence sous condition
+  définition multiplicateur_majoration_loyer_référence
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6834,7 +6974,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 5,0
+  conséquence égal à
+    5,0
 ```
 
 d) Le forfait " R0 ", visé au 5° de l'article D. 823-17 du même code, dont les valeurs sont
@@ -6842,10 +6983,11 @@ fixées à l'article 15 ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
 
   exception métropole
-  définition multiplicateur_majoration_r0 sous condition
+  définition multiplicateur_majoration_r0
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6857,7 +6999,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
       -- n'importe quel : faux
     )
     et nombre_personnes_à_charge >= 6
-  conséquence égal à 0,0
+  conséquence égal à
+    0,0
 ```
 
 e) Les mensualités plafonds visées à l'article D. 842-6 du même code, dont les valeurs sont
@@ -6865,20 +7008,20 @@ fixées à l'article 33 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_limitation_dom_tom
   sous condition
     nombre_personnes_à_charge >= 6
     et selon résidence sous forme
-    -- Guadeloupe : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
+      -- Guadeloupe : vrai
+      -- Martinique : vrai
+      -- LaRéunion : vrai
+      -- Mayotte : vrai
+      -- SaintBarthélemy : vrai
+      -- SaintMartin : vrai
+      -- n'importe quel : faux
   conséquence égal à
     calcul_plafond_mensualité_d842_6 de date_calcul, 6
 ```
@@ -6888,9 +7031,10 @@ même code, pour un ménage ayant un enfant à charge, est remplacée par " 7 58
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -6919,19 +7063,19 @@ Par personne supplémentaire à charge dans la limite de six personnes à charge
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,14€ + 9,29€ * (décimal de nombre_personnes_à_charge)
@@ -6942,19 +7086,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,14€ + 9,29€ * (décimal de nombre_personnes_à_charge)
@@ -6965,19 +7109,19 @@ champ d'application CalculAllocationLogementAccessionPropriété
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       36,14€ + 9,29€ * (décimal de nombre_personnes_à_charge)
@@ -7000,19 +7144,19 @@ Majoration par personne à charge dans la limite de six personnes à charge   9,
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -7033,19 +7177,19 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     si montant > limite alors limite sinon montant
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     soit montant égal à
       (
@@ -7084,19 +7228,19 @@ Couple sans enfant                  2,99%
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2020-10-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -7179,18 +7323,18 @@ dispositions sont applicables pour les prestations dues à compter du 1er janvie
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2020-01-01| et date_courante < |2021-01-01|:
+sous condition date_courante >= |2020-01-01| et date_courante < |2021-01-01|:
   exception article_46
-  # Normalement la règle suivante aurait du être une exception à l'étiquette
-  # "métropole". Cependant, la version de l'article 46 de l'arrêté du 27
-  # septembre 2019 en vigueur du 1er janvier 2020 au 31 décembre 2020 prévoit
-  # également dans le cas de l'outre-mer un remplacement du de la valeur de R0
-  # de l'article 15 dans le cas de une personne à charge. Pour faire exister
-  # cette règle plus précise valable uniquement pour Mayotte, nous la codons ici
-  # comme une exception au tableau de l'article 46 afin d'éviter le conflit
-  # entre deux règles qui s'activent en même temps.
-  définition abattement_forfaitaire_d823_17 sous condition
-    résidence sous forme Mayotte
+    # Normalement la règle suivante aurait du être une exception à l'étiquette
+    # "métropole". Cependant, la version de l'article 46 de l'arrêté du 27
+    # septembre 2019 en vigueur du 1er janvier 2020 au 31 décembre 2020 prévoit
+    # également dans le cas de l'outre-mer un remplacement du de la valeur de R0
+    # de l'article 15 dans le cas de une personne à charge. Pour faire exister
+    # cette règle plus précise valable uniquement pour Mayotte, nous la codons ici
+    # comme une exception au tableau de l'article 46 afin d'éviter le conflit
+    # entre deux règles qui s'activent en même temps.
+  définition abattement_forfaitaire_d823_17
+  sous condition résidence sous forme Mayotte
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -7225,13 +7369,14 @@ soixante-deux ans pour les assurés nés à compter du 1er janvier 1955.
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante < |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    date_naissance_assuré >= |1955-01-01|
-  conséquence égal à 62 an
+sous condition date_courante < |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition date_naissance_assuré >= |1955-01-01|
+  conséquence égal à
+    62 an
 
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante < |2023-09-01|:
+sous condition date_courante < |2023-09-01|:
   définition ouverture_droits_retraite.date_naissance_assuré égal à
     demandeur.date_naissance
   définition âge_l161_17_2_sécu égal à
@@ -7265,7 +7410,7 @@ de cinq années ;
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante < |2023-09-01|:
+sous condition date_courante < |2023-09-01|:
   définition âge_l351_8_1_sécu égal à âge_l161_17_2_sécu + 5 an
 ```
 
@@ -7320,10 +7465,11 @@ L'âge prévu au second alinéa de l'article L. 161-17-2 est fixé à :
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante < |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    date_naissance_assuré < |1951-07-01|
-  conséquence égal à 60 an
+sous condition date_courante < |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition date_naissance_assuré < |1951-07-01|
+  conséquence égal à
+    60 an
 ```
 
 2° Soixante ans et quatre mois pour les assurés nés entre le 1er juillet
@@ -7331,41 +7477,46 @@ champ d'application OuvertureDroitsRetraite
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante < |2023-09-01|:
-  définition âge_ouverture_droit sous condition
+sous condition date_courante < |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition
     date_naissance_assuré >= |1951-07-01|
     et date_naissance_assuré <= |1951-12-31|
-  conséquence égal à 60 an + 4 mois
+  conséquence égal à
+    60 an + 4 mois
 ```
 
 3° Soixante ans et neuf mois pour les assurés nés en 1952 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante < |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1952
-  conséquence égal à 60 an + 9 mois
+sous condition date_courante < |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1952
+  conséquence égal à
+    60 an + 9 mois
 ```
 
 4° Soixante et un ans et deux mois pour les assurés nés en 1953 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante < |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1953
-  conséquence égal à 61 an + 2 mois
+sous condition date_courante < |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1953
+  conséquence égal à
+    61 an + 2 mois
 ```
 
 5° Soixante et un ans et sept mois pour les assurés nés en 1954 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante < |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1954
-  conséquence égal à 61 an + 7 mois
+sous condition date_courante < |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1954
+  conséquence égal à
+    61 an + 7 mois
 ```
 
 6° Soixante deux ans pour les assurés nés à compter du 1er janvier 1955.

--- a/tests/fr/archives_cgi.catala_fr.result
+++ b/tests/fr/archives_cgi.catala_fr.result
@@ -113,9 +113,10 @@ la première tranche du barème de l'impôt sur le revenu.
 
 ```catala
 champ d'application TraitementsSalairesDéclarant:
-  définition plafond_déduction_frais_professionnels sous condition
-    année_revenus = 2022
-  conséquence égal à 13 522 €
+  définition plafond_déduction_frais_professionnels
+  sous condition année_revenus = 2022
+  conséquence égal à
+    13 522 €
 ```
 
 Le montant de la déduction forfaitaire pour frais professionnels ne peut être inférieur à 472 €,
@@ -125,11 +126,13 @@ l'article 6.
 
 ```catala
 champ d'application TraitementsSalairesDéclarant:
-  définition minimum_déduction_frais_professionnels sous condition
+  définition minimum_déduction_frais_professionnels
+  sous condition
     # Ici la valeur de 472 € est implicitement valable pour 2022 comme le
     # plafond précédent
     année_revenus = 2022
-  conséquence égal à 472 €
+  conséquence égal à
+    472 €
 ```
 
 La somme figurant au troisième alinéa est révisée chaque année dans la même proportion que la
@@ -346,13 +349,14 @@ tranche du barème de l'impôt sur le revenu.
 
 ```catala
 champ d'application TraitementsSalairesFoyerFiscal:
-  définition plafond_abattement_pensions_retraites_rentes sous condition
-    année_revenus = 2022
-  # Ici, l'année des revenus est soumis à ce plafond est 2022 car le montant
-  # du plafond est remis à jour pour le millésime (N-1) en mai de l'année N
-  # suivant les évolutions du barème de l'IR votées à la fin de l'année (N-1)
-  # pour le millésime (N-1).
-  conséquence égal à 4 123€
+  définition plafond_abattement_pensions_retraites_rentes
+  sous condition année_revenus = 2022
+    # Ici, l'année des revenus est soumis à ce plafond est 2022 car le montant
+    # du plafond est remis à jour pour le millésime (N-1) en mai de l'année N
+    # suivant les évolutions du barème de l'IR votées à la fin de l'année (N-1)
+    # pour le millésime (N-1).
+  conséquence égal à
+    4 123€
 ```
 
 L'abattement indiqué au deuxième alinéa ne peut être inférieur à 422 €, sans
@@ -364,10 +368,11 @@ barème de l'impôt sur le revenu.
 
 ```catala
 champ d'application TraitementsSalairesDéclarant:
-  définition minimum_abattement_pensions_retraites_rentes sous condition
-    année_revenus = 2022
-  # Voir commentaire sur le plafond ci-dessus.
-  conséquence égal à 422€
+  définition minimum_abattement_pensions_retraites_rentes
+  sous condition année_revenus = 2022
+    # Voir commentaire sur le plafond ci-dessus.
+  conséquence égal à
+    422€
 ```
 
 b. Les dispositions du a sont applicables aux allocations et indemnités
@@ -530,13 +535,14 @@ l'article 6 bénéficie d'une demi-part supplémentaire de quotient familial par
 personne ainsi rattachée.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus = 2022:
+champ d'application NombreDeParts
+sous condition année_revenus = 2022:
   définition nombre_de_parts
     état article_196_B
   égal à
     nombre_de_parts
     + décimal de foyer_fiscal.nombre_enfants_majeurs_célibataires_sans_enfant
-    * 0,5
+      * 0,5
 ```
 
 Si la personne rattachée est mariée ou a des enfants à charge, l'avantage
@@ -547,7 +553,8 @@ l'autre de leurs parents, l'abattement auquel ils ouvrent droit pour le
 contribuable, est égal à la moitié de cette somme.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus = 2022:
+champ d'application NombreDeParts
+sous condition année_revenus = 2022:
   # Attention, l'année des revenus sur lesquels porte ce montant d'abattement
   # est généralement l'année N-1 si la version de cet article entre en vigueur
   # l'année N. En effet, l'abattement sur la déclaration de l'année N-1 est

--- a/tests/fr/arrete_2019-09-27.catala_fr.result
+++ b/tests/fr/arrete_2019-09-27.catala_fr.result
@@ -104,11 +104,12 @@ champ d'application CalculAllocationLogement:
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
 
   # Colonne 1
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -119,7 +120,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonne 2
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -134,8 +136,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
 
   # Colonnes 3 et 4
   étiquette base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -191,7 +193,8 @@ compter du 1er octobre 2024.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01|
+sous condition
+  date_courante >= |2024-10-01|
   et logement_est_chambre:
 
   étiquette chambre exception base
@@ -202,8 +205,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 242,39€
 
   exception chambre
-  définition plafond_loyer_d823_16_2 sous condition
-    âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
+  définition plafond_loyer_d823_16_2
+  sous condition âgées_ou_handicap_adultes_hébergées_onéreux_particuliers
   conséquence égal à
     selon zone sous forme
     -- Zone1 : 247,28€
@@ -236,7 +239,7 @@ compter du 1er octobre 2024.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges_d823_16 égal à
@@ -266,7 +269,7 @@ III	 2,5                      3,1
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition plafond_dégressivité_d823_16 égal à
     selon zone sous forme
@@ -288,7 +291,7 @@ du même code est fixé à 5 euros.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d823_16 égal à 5 €
 ```
@@ -302,7 +305,7 @@ personnalisée au logement.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_minimal_aide_d823_16 égal à
     selon type_aide sous forme
@@ -319,11 +322,13 @@ défini au 2° de l'article D. 823-16 du même code et du forfait charge ou 39,1
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01|:
+sous condition date_courante >= |2023-10-01|:
   définition participation_minimale égal à
-    si (loyer_éligible + montant_forfaitaire_charges_d823_16)
+    si
+      (loyer_éligible + montant_forfaitaire_charges_d823_16)
       * 8,5%
-      >= 39,15 € alors
+      >= 39,15 €
+    alors
       (loyer_éligible + montant_forfaitaire_charges_d823_16) * 8,5%
     sinon
       39,15 €
@@ -363,7 +368,7 @@ Majoration par personne à charge supplémentaire     -0,06 %
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   étiquette base
   définition taux_composition_familiale égal à
     si nombre_personnes_à_charge = 0 alors
@@ -400,7 +405,7 @@ RL est exprimé en pourcentage et arrondi à la deuxième décimale.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   définition rapport_loyers égal à
     arrondi de ((loyer_éligible / loyer_référence) * 100,0) / 100,0
 ```
@@ -423,7 +428,7 @@ $\textrm{TL}=0 \%$    $\textrm{TL}=0,45 \%\times (\textrm{RL}-45\%)$ $\textrm{TL
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   # Ici on choisit de mettre des >= pour inclure le résultat sur la crête
   # dans la case de droite ; nous avons bien vérifié que sur la crête le
   # résultat est le même à gauche et à droite.
@@ -460,7 +465,7 @@ Majoration par personne à charge	                    57,61
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
 
   étiquette base
   définition multiplicateur_majoration_loyer_référence égal à
@@ -499,7 +504,7 @@ Personne seule ou couple ayant :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_r0 égal à
@@ -559,14 +564,15 @@ charge supplémentaire              48,91  43,21  39,35
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2024-10-01| et colocation:
+sous condition date_courante >= |2024-10-01| et colocation:
 
   # Ici l'exception est rapportée au cas de base puisqu'on suppose
   # qu'on ne peut pas être en colocation dans un logement constitué
   # d'une seule chambre.
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme PersonneSeule)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -576,7 +582,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 201,99€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
+  définition plafond_loyer_d823_16_2
+  sous condition
     (situation_familiale_calcul_apl sous forme Couple)
     et nombre_personnes_à_charge = 0
   conséquence égal à
@@ -586,8 +593,8 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     -- Zone3 : 244,86€
 
   exception base
-  définition plafond_loyer_d823_16_2 sous condition
-    nombre_personnes_à_charge >= 1
+  définition plafond_loyer_d823_16_2
+  sous condition nombre_personnes_à_charge >= 1
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -608,7 +615,7 @@ Majoration par personne à charge 13,60
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2023-10-01| et colocation:
+sous condition date_courante >= |2023-10-01| et colocation:
   étiquette colocation_métropole exception base_outre_mer
   définition montant_forfaitaire_charges_d823_16 égal à
     (
@@ -655,9 +662,10 @@ Par personne supplémentaire à charge	                   430	  379     346
 # l'avènement de l'euro mais pour le calcul des APL en euros il faut
 # que la mensualité plafond soit exprimée en euros. Donc nous convertissons.
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_signature_prêt >= |1992-06-30|
     et date_signature_prêt < |1994-11-27|
     et ancienneté_logement sous forme Neuf
@@ -722,9 +730,10 @@ Par personne supplémentaire à charge	                   347	  305     279
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_signature_prêt >= |1992-06-30|
     et date_signature_prêt < |1994-11-27|
     et ancienneté_logement sous forme Ancien
@@ -791,9 +800,10 @@ Par personne supplémentaire à charge	                   380	  335     305
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_signature_prêt >= |1994-11-27|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_32
@@ -858,9 +868,10 @@ Par personne supplémentaire à charge	                   306	  269     246
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_signature_prêt >= |1994-11-27|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_32
@@ -936,22 +947,23 @@ Par personne supplémentaire à charge                     102
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   exception petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2023-01-01|
     et date_signature_prêt >= |1992-06-30|
     et date_signature_prêt <= |1994-11-27|
     et
-    # La borne supérieure de la date de signature du prêt est implicite dans
-    # la rédaction actuelle mais confirmée par un mail de DGALN/DHUP/FE4 le
-    # 19/01/2023: "sur l'article 18, la nouvelle rédaction reprend l'ancienne :
-    # dans l'ancienne, nous avions un 1° qui prévoyait, à partir du 30/06/1992,
-    # un a), un b) et un c). Le 2° prévoyait à partir du 27/11/1994 un a) et
-    # un b). Le c) n'était plus mentionné, ce qui est également le cas à
-    # présent". Les anciennes et nouvelles version font référence aux
-    # changements introduits par l’arrêté du 26 décembre 2022.
+      # La borne supérieure de la date de signature du prêt est implicite dans
+      # la rédaction actuelle mais confirmée par un mail de DGALN/DHUP/FE4 le
+      # 19/01/2023: "sur l'article 18, la nouvelle rédaction reprend l'ancienne :
+      # dans l'ancienne, nous avions un 1° qui prévoyait, à partir du 30/06/1992,
+      # un a), un b) et un c). Le 2° prévoyait à partir du 27/11/1994 un a) et
+      # un b). Le c) n'était plus mentionné, ce qui est également le cas à
+      # présent". Les anciennes et nouvelles version font référence aux
+      # changements introduits par l’arrêté du 26 décembre 2022.
     (
       selon ancienneté_logement sous forme
       -- Ancien contenu amélioré_par_occupant :
@@ -1202,10 +1214,11 @@ ces dispositions sont applicables pour les prestations dues à compter du 1er ja
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |1992-06-30|
     et date_signature_prêt < |1994-11-27|
@@ -1260,7 +1273,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |1992-06-30|
     et date_signature_prêt < |1994-11-27|
@@ -1315,7 +1329,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |1994-11-27|
     et date_signature_prêt < |2000-06-30|
@@ -1370,7 +1385,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |1994-11-27|
     et date_signature_prêt < |2000-06-30|
@@ -1425,7 +1441,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2000-06-30|
     et date_signature_prêt <= |2001-06-30|
@@ -1480,7 +1497,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2000-06-30|
     et date_signature_prêt <= |2001-06-30|
@@ -1535,7 +1553,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2001-07-01|
     et date_signature_prêt < |2001-12-31|
@@ -1590,61 +1609,63 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2002-01-01|
     et date_signature_prêt < |2002-06-30|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 308,71€
-              -- Couple : 372,43€
-            )
-          sinon
-            (
-              436,15€
-              + 63,72€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 275,48€
-              -- Couple : 331,48€
-            )
-          sinon
-            (
-              387,68€
-              + 56,1€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 257,18€
-              -- Couple : 308,4€
-            )
-          sinon
-            (
-              359,62€
-              + 51,22€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 308,71€
+            -- Couple : 372,43€
+          )
+        sinon
+          (
+            436,15€
+            + 63,72€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 275,48€
+            -- Couple : 331,48€
+          )
+        sinon
+          (
+            387,68€
+            + 56,1€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 257,18€
+            -- Couple : 308,4€
+          )
+        sinon
+          (
+            359,62€
+            + 51,22€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2001-07-01|
     et date_signature_prêt < |2001-12-31|
@@ -1699,1568 +1720,1597 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
     * taux_francs_vers_euros
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2002-01-01|
     et date_signature_prêt < |2002-06-30|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 248,49€
-              -- Couple : 299,87€
-            )
-          sinon
-            (
-              351,25€
-              + 51,38€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 221,51€
-              -- Couple : 266,79€
-            )
-          sinon
-            (
-              312,07€
-              + 45,28€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 206,87€
-              -- Couple : 248,18€
-            )
-          sinon
-            (
-              289,49€
-              + 41,31€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 248,49€
+            -- Couple : 299,87€
+          )
+        sinon
+          (
+            351,25€
+            + 51,38€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 221,51€
+            -- Couple : 266,79€
+          )
+        sinon
+          (
+            312,07€
+            + 45,28€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 206,87€
+            -- Couple : 248,18€
+          )
+        sinon
+          (
+            289,49€
+            + 41,31€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2002-06-30|
     et date_signature_prêt < |2003-06-30|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 312,41€
-              -- Couple : 376,89€
-            )
-          sinon
-            (
-              441,37€
-              + 64,48€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 278,79€
-              -- Couple : 335,56€
-            )
-          sinon
-            (
-              392,33€
-              + 56,77€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 260,27€
-              -- Couple : 312,1€
-            )
-          sinon
-            (
-              363,93€
-              + 51,83€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 312,41€
+            -- Couple : 376,89€
+          )
+        sinon
+          (
+            441,37€
+            + 64,48€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 278,79€
+            -- Couple : 335,56€
+          )
+        sinon
+          (
+            392,33€
+            + 56,77€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 260,27€
+            -- Couple : 312,1€
+          )
+        sinon
+          (
+            363,93€
+            + 51,83€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2002-06-30|
     et date_signature_prêt < |2003-06-30|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 251,47€
-              -- Couple : 303,47€
-            )
-          sinon
-            (
-              355,47€
-              + 52€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 224,17€
-              -- Couple : 269,99€
-            )
-          sinon
-            (
-              315,81€
-              + 45,82€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 209,35€
-              -- Couple : 251,16€
-            )
-          sinon
-            (
-              292,97€
-              + 41,81€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 251,47€
+            -- Couple : 303,47€
+          )
+        sinon
+          (
+            355,47€
+            + 52€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 224,17€
+            -- Couple : 269,99€
+          )
+        sinon
+          (
+            315,81€
+            + 45,82€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 209,35€
+            -- Couple : 251,16€
+          )
+        sinon
+          (
+            292,97€
+            + 41,81€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2003-06-30|
     et date_signature_prêt < |2005-08-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 316,16€
-              -- Couple : 381,41€
-            )
-          sinon
-            (
-              446,66€
-              + 65,25€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 282,14€
-              -- Couple : 339,59€
-            )
-          sinon
-            (
-              397,04€
-              + 57,45€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 263,39€
-              -- Couple : 315,84€
-            )
-          sinon
-            (
-              368,29€
-              + 52,45€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 316,16€
+            -- Couple : 381,41€
+          )
+        sinon
+          (
+            446,66€
+            + 65,25€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 282,14€
+            -- Couple : 339,59€
+          )
+        sinon
+          (
+            397,04€
+            + 57,45€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 263,39€
+            -- Couple : 315,84€
+          )
+        sinon
+          (
+            368,29€
+            + 52,45€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2003-06-30|
     et date_signature_prêt < |2005-08-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 254,49€
-              -- Couple : 307,11€
-            )
-          sinon
-            (
-              359,73€
-              + 52,62€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 226,86€
-              -- Couple : 273,23€
-            )
-          sinon
-            (
-              319,6€
-              + 46,37€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 211,86€
-              -- Couple : 254,17€
-            )
-          sinon
-            (
-              296,48€
-              + 42,31€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 254,49€
+            -- Couple : 307,11€
+          )
+        sinon
+          (
+            359,73€
+            + 52,62€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 226,86€
+            -- Couple : 273,23€
+          )
+        sinon
+          (
+            319,6€
+            + 46,37€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 211,86€
+            -- Couple : 254,17€
+          )
+        sinon
+          (
+            296,48€
+            + 42,31€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2005-08-31|
     et date_signature_prêt < |2006-12-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 321,85€
-              -- Couple : 388,27€
-            )
-          sinon
-            (
-              454,69€
-              + 66,42€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 287,22€
-              -- Couple : 345,7€
-            )
-          sinon
-            (
-              404,18€
-              + 58,48€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 268,13€
-              -- Couple : 321,52€
-            )
-          sinon
-            (
-              374,91€
-              + 53,39€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 321,85€
+            -- Couple : 388,27€
+          )
+        sinon
+          (
+            454,69€
+            + 66,42€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 287,22€
+            -- Couple : 345,7€
+          )
+        sinon
+          (
+            404,18€
+            + 58,48€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 268,13€
+            -- Couple : 321,52€
+          )
+        sinon
+          (
+            374,91€
+            + 53,39€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2005-08-31|
     et date_signature_prêt < |2006-12-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 259,07€
-              -- Couple : 312,64€
-            )
-          sinon
-            (
-              366,21€
-              + 53,57€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 230,94€
-              -- Couple : 278,14€
-            )
-          sinon
-            (
-              325,34€
-              + 47,2€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 215,67€
-              -- Couple : 258,74€
-            )
-          sinon
-            (
-              301,81€
-              + 43,07€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 259,07€
+            -- Couple : 312,64€
+          )
+        sinon
+          (
+            366,21€
+            + 53,57€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 230,94€
+            -- Couple : 278,14€
+          )
+        sinon
+          (
+            325,34€
+            + 47,2€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 215,67€
+            -- Couple : 258,74€
+          )
+        sinon
+          (
+            301,81€
+            + 43,07€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2006-12-31|
     et date_signature_prêt < |2007-12-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 330,86€
-              -- Couple : 399,14€
-            )
-          sinon
-            (
-              467,42€
-              + 68,28€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 295,26€
-              -- Couple : 355,38€
-            )
-          sinon
-            (
-              415,5€
-              + 60,12€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 275,64€
-              -- Couple : 330,52€
-            )
-          sinon
-            (
-              385,41€
-              + 54,88€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 330,86€
+            -- Couple : 399,14€
+          )
+        sinon
+          (
+            467,42€
+            + 68,28€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 295,26€
+            -- Couple : 355,38€
+          )
+        sinon
+          (
+            415,5€
+            + 60,12€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 275,64€
+            -- Couple : 330,52€
+          )
+        sinon
+          (
+            385,41€
+            + 54,88€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2006-12-31|
     et date_signature_prêt < |2007-12-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 266,32€
-              -- Couple : 321,39€
-            )
-          sinon
-            (
-              376,46€
-              + 55,07€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 237,41€
-              -- Couple : 285,93€
-            )
-          sinon
-            (
-              334,45€
-              + 48,52€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 221,71€
-              -- Couple : 365,98€
-            )
-          sinon
-            (
-              310,26€
-              + 44,28€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 266,32€
+            -- Couple : 321,39€
+          )
+        sinon
+          (
+            376,46€
+            + 55,07€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 237,41€
+            -- Couple : 285,93€
+          )
+        sinon
+          (
+            334,45€
+            + 48,52€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 221,71€
+            -- Couple : 365,98€
+          )
+        sinon
+          (
+            310,26€
+            + 44,28€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2007-12-31|
     et date_signature_prêt < |2008-12-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 339,99€
-              -- Couple : 410,16€
-            )
-          sinon
-            (
-              480,32€
-              + 70,16€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 303,41€
-              -- Couple : 365,19€
-            )
-          sinon
-            (
-              426,97€
-              + 61,78€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 283,25€
-              -- Couple : 339,64€
-            )
-          sinon
-            (
-              396,05€
-              + 56,39€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 339,99€
+            -- Couple : 410,16€
+          )
+        sinon
+          (
+            480,32€
+            + 70,16€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 303,41€
+            -- Couple : 365,19€
+          )
+        sinon
+          (
+            426,97€
+            + 61,78€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 283,25€
+            -- Couple : 339,64€
+          )
+        sinon
+          (
+            396,05€
+            + 56,39€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2007-12-31|
     et date_signature_prêt < |2008-12-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 273,67€
-              -- Couple : 330,26€
-            )
-          sinon
-            (
-              386,85€
-              + 56,59€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 243,96€
-              -- Couple : 293,82€
-            )
-          sinon
-            (
-              343,68€
-              + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 227,83€
-              -- Couple : 273,32€
-            )
-          sinon
-            (
-              318,82€
-              + 45,5€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 273,67€
+            -- Couple : 330,26€
+          )
+        sinon
+          (
+            386,85€
+            + 56,59€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 243,96€
+            -- Couple : 293,82€
+          )
+        sinon
+          (
+            343,68€
+            + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 227,83€
+            -- Couple : 273,32€
+          )
+        sinon
+          (
+            318,82€
+            + 45,5€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2008-12-31|
     et date_signature_prêt < |2009-12-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 350,02€
-              -- Couple : 422,26€
-            )
-          sinon
-            (
-              494,49€
-              + 72,23€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 312,36€
-              -- Couple : 375,96€
-            )
-          sinon
-            (
-              439,57€
-              + 63,6€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 291,61€
-              -- Couple : 349,66€
-            )
-          sinon
-            (
-              407,73€
-              + 58,05€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 350,02€
+            -- Couple : 422,26€
+          )
+        sinon
+          (
+            494,49€
+            + 72,23€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 312,36€
+            -- Couple : 375,96€
+          )
+        sinon
+          (
+            439,57€
+            + 63,6€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 291,61€
+            -- Couple : 349,66€
+          )
+        sinon
+          (
+            407,73€
+            + 58,05€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2008-12-31|
     et date_signature_prêt < |2009-12-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 281,74€
-              -- Couple : 340€
-            )
-          sinon
-            (
-              398,26€
-              + 58,26€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 251,16€
-              -- Couple : 302,49€
-            )
-          sinon
-            (
-              353,82€
-              + 51,33€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 234,55€
-              -- Couple : 281,38€
-            )
-          sinon
-            (
-              328,23€
-              + 46,84€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 281,74€
+            -- Couple : 340€
+          )
+        sinon
+          (
+            398,26€
+            + 58,26€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 251,16€
+            -- Couple : 302,49€
+          )
+        sinon
+          (
+            353,82€
+            + 51,33€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 234,55€
+            -- Couple : 281,38€
+          )
+        sinon
+          (
+            328,23€
+            + 46,84€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2009-12-31|
     et date_signature_prêt < |2010-12-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 351,14€
-              -- Couple : 423,61€
-            )
-          sinon
-            (
-              496,07€
-              + 72,46€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 313,36€
-              -- Couple : 377,16€
-            )
-          sinon
-            (
-              440,98€
-              + 63,8€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 292,54€
-              -- Couple : 350,78€
-            )
-          sinon
-            (
-              409,03€
-              + 58,24€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 351,14€
+            -- Couple : 423,61€
+          )
+        sinon
+          (
+            496,07€
+            + 72,46€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 313,36€
+            -- Couple : 377,16€
+          )
+        sinon
+          (
+            440,98€
+            + 63,8€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 292,54€
+            -- Couple : 350,78€
+          )
+        sinon
+          (
+            409,03€
+            + 58,24€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2009-12-31|
     et date_signature_prêt < |2010-12-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 282,64€
-              -- Couple : 341,09€
-            )
-          sinon
-            (
-              399,53€
-              + 58,45€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 251,96€
-              -- Couple : 303,46€
-            )
-          sinon
-            (
-              354,95€
-              + 51,49€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 235,3€
-              -- Couple : 282,28€
-            )
-          sinon
-            (
-              329,28€
-              + 46,99€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 282,64€
+            -- Couple : 341,09€
+          )
+        sinon
+          (
+            399,53€
+            + 58,45€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 251,96€
+            -- Couple : 303,46€
+          )
+        sinon
+          (
+            354,95€
+            + 51,49€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 235,3€
+            -- Couple : 282,28€
+          )
+        sinon
+          (
+            329,28€
+            + 46,99€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2010-12-31|
     et date_signature_prêt < |2011-12-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 355€
-              -- Couple : 428,27€
-            )
-          sinon
-            (
-              501,53€
-              + 73,26€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 316,81€
-              -- Couple : 381,31€
-            )
-          sinon
-            (
-              445,83€
-              + 64,5€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 295,76€
-              -- Couple : 354,64€
-            )
-          sinon
-            (
-              413,53€
-              + 58,88€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 355€
+            -- Couple : 428,27€
+          )
+        sinon
+          (
+            501,53€
+            + 73,26€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 316,81€
+            -- Couple : 381,31€
+          )
+        sinon
+          (
+            445,83€
+            + 64,5€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 295,76€
+            -- Couple : 354,64€
+          )
+        sinon
+          (
+            413,53€
+            + 58,88€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2010-12-31|
     et date_signature_prêt < |2011-12-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 285,75€
-              -- Couple : 344,84€
-            )
-          sinon
-            (
-              403,92€
-              + 59,09€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 254,73€
-              -- Couple : 306,8€
-            )
-          sinon
-            (
-              358,85€
-              + 52,06€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 237,89€
-              -- Couple : 285,39€
-            )
-          sinon
-            (
-              332,9€
-              + 47,51€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 285,75€
+            -- Couple : 344,84€
+          )
+        sinon
+          (
+            403,92€
+            + 59,09€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 254,73€
+            -- Couple : 306,8€
+          )
+        sinon
+          (
+            358,85€
+            + 52,06€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 237,89€
+            -- Couple : 285,39€
+          )
+        sinon
+          (
+            332,9€
+            + 47,51€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2011-12-31|
     et date_signature_prêt < |2012-12-31|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 358,55€
-              -- Couple : 432,55€
-            )
-          sinon
-            (
-              506,55€
-              + 73,99€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 319,98€
-              -- Couple : 385,12€
-            )
-          sinon
-            (
-              450,29€
-              + 65,15€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 298,72€
-              -- Couple : 358,19€
-            )
-          sinon
-            (
-              417,67€
-              + 59,47€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 358,55€
+            -- Couple : 432,55€
+          )
+        sinon
+          (
+            506,55€
+            + 73,99€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 319,98€
+            -- Couple : 385,12€
+          )
+        sinon
+          (
+            450,29€
+            + 65,15€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 298,72€
+            -- Couple : 358,19€
+          )
+        sinon
+          (
+            417,67€
+            + 59,47€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2011-12-31|
     et date_signature_prêt < |2012-12-31|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 288,61€
-              -- Couple : 348,29€
-            )
-          sinon
-            (
-              407,96€
-              + 59,68€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 257,28€
-              -- Couple : 309,87€
-            )
-          sinon
-            (
-              362,44€
-              + 52,58€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 240,27€
-              -- Couple : 288,24€
-            )
-          sinon
-            (
-              336,23€
-              + 47,99€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 288,61€
+            -- Couple : 348,29€
+          )
+        sinon
+          (
+            407,96€
+            + 59,68€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 257,28€
+            -- Couple : 309,87€
+          )
+        sinon
+          (
+            362,44€
+            + 52,58€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 240,27€
+            -- Couple : 288,24€
+          )
+        sinon
+          (
+            336,23€
+            + 47,99€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2012-12-31|
     et date_signature_prêt < |2014-09-30|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 366,26€
-              -- Couple : 441,85€
-            )
-          sinon
-            (
-              517,44€
-              + 75,58€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 326,86€
-              -- Couple : 393,4€
-            )
-          sinon
-            (
-              459,97€
-              + 66,55€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 305,14€
-              -- Couple : 365,89€
-            )
-          sinon
-            (
-              426,65€
-              + 60,75€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 366,26€
+            -- Couple : 441,85€
+          )
+        sinon
+          (
+            517,44€
+            + 75,58€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 326,86€
+            -- Couple : 393,4€
+          )
+        sinon
+          (
+            459,97€
+            + 66,55€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 305,14€
+            -- Couple : 365,89€
+          )
+        sinon
+          (
+            426,65€
+            + 60,75€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2012-12-31|
     et date_signature_prêt < |2014-09-30|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 294,82€
-              -- Couple : 355,78€
-            )
-          sinon
-            (
-              416,73€
-              + 60,96€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 262,81€
-              -- Couple : 316,53€
-            )
-          sinon
-            (
-              370,23€
-              + 53,71€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 245,44€
-              -- Couple : 294,44€
-            )
-          sinon
-            (
-              343,46€
-              + 49,02€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 294,82€
+            -- Couple : 355,78€
+          )
+        sinon
+          (
+            416,73€
+            + 60,96€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 262,81€
+            -- Couple : 316,53€
+          )
+        sinon
+          (
+            370,23€
+            + 53,71€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 245,44€
+            -- Couple : 294,44€
+          )
+        sinon
+          (
+            343,46€
+            + 49,02€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2014-09-30|
     et date_signature_prêt < |2015-09-30|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 368,35€
-              -- Couple : 444,37€
-            )
-          sinon
-            (
-              520,39€
-              + 76,01€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 328,72€
-              -- Couple : 395,64€
-            )
-          sinon
-            (
-              462,59€
-              + 66,93€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 306,88€
-              -- Couple : 367,98€
-            )
-          sinon
-            (
-              429,08€
-              + 61,1€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 368,35€
+            -- Couple : 444,37€
+          )
+        sinon
+          (
+            520,39€
+            + 76,01€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 328,72€
+            -- Couple : 395,64€
+          )
+        sinon
+          (
+            462,59€
+            + 66,93€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 306,88€
+            -- Couple : 367,98€
+          )
+        sinon
+          (
+            429,08€
+            + 61,1€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2014-09-30|
     et date_signature_prêt < |2015-09-30|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 296,5€
-              -- Couple : 357,81€
-            )
-          sinon
-            (
-              419,11€
-              + 61,31€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 264,31€
-              -- Couple : 318,33€
-            )
-          sinon
-            (
-              372,34€
-              + 54,02€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 246,84€
-              -- Couple : 296,12€
-            )
-          sinon
-            (
-              345,42€
-              + 49,3€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 296,5€
+            -- Couple : 357,81€
+          )
+        sinon
+          (
+            419,11€
+            + 61,31€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 264,31€
+            -- Couple : 318,33€
+          )
+        sinon
+          (
+            372,34€
+            + 54,02€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 246,84€
+            -- Couple : 296,12€
+          )
+        sinon
+          (
+            345,42€
+            + 49,3€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2015-09-30|
     et date_signature_prêt < |2017-09-30|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 368,64€
-              -- Couple : 444,73€
-            )
-          sinon
-            (
-              520,81€
-              + 76,07€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 328,98€
-              -- Couple : 395,96€
-            )
-          sinon
-            (
-              462,96€
-              + 66,98€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 307,13€
-              -- Couple : 368,27€
-            )
-          sinon
-            (
-              429,42€
-              + 61,15€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 368,64€
+            -- Couple : 444,73€
+          )
+        sinon
+          (
+            520,81€
+            + 76,07€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 328,98€
+            -- Couple : 395,96€
+          )
+        sinon
+          (
+            462,96€
+            + 66,98€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 307,13€
+            -- Couple : 368,27€
+          )
+        sinon
+          (
+            429,42€
+            + 61,15€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2015-09-30|
     et date_signature_prêt < |2017-09-30|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 296,74€
-              -- Couple : 358,1€
-            )
-          sinon
-            (
-              419,45€
-              + 61,36€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 264,52€
-              -- Couple : 318,58€
-            )
-          sinon
-            (
-              372,64€
-              + 54,06€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 247,04€
-              -- Couple : 296,36€
-            )
-          sinon
-            (
-              345,7€
-              + 49,34€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 296,74€
+            -- Couple : 358,1€
+          )
+        sinon
+          (
+            419,45€
+            + 61,36€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 264,52€
+            -- Couple : 318,58€
+          )
+        sinon
+          (
+            372,64€
+            + 54,06€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 247,04€
+            -- Couple : 296,36€
+          )
+        sinon
+          (
+            345,7€
+            + 49,34€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2017-09-30|
     et date_signature_prêt < |2019-09-30|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 371,4€
-              -- Couple : 448,07€
-            )
-          sinon
-            (
-              524,72€
-              + 76,64€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 331,45€
-              -- Couple : 398,93€
-            )
-          sinon
-            (
-              466,43€
-              + 67,48€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 309,43€
-              -- Couple : 371,03€
-            )
-          sinon
-            (
-              432,64€
-              + 61,61€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 371,4€
+            -- Couple : 448,07€
+          )
+        sinon
+          (
+            524,72€
+            + 76,64€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 331,45€
+            -- Couple : 398,93€
+          )
+        sinon
+          (
+            466,43€
+            + 67,48€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 309,43€
+            -- Couple : 371,03€
+          )
+        sinon
+          (
+            432,64€
+            + 61,61€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2017-09-30|
     et date_signature_prêt < |2019-09-30|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 298,97€
-              -- Couple : 360,79€
-            )
-          sinon
-            (
-              422,6€
-              + 61,82€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 266,5€
-              -- Couple : 320,97€
-            )
-          sinon
-            (
-              375,43€
-              + 54,47€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 248,89€
-              -- Couple : 298,58€
-            )
-          sinon
-            (
-              348,29€
-              + 49,71€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 298,97€
+            -- Couple : 360,79€
+          )
+        sinon
+          (
+            422,6€
+            + 61,82€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 266,5€
+            -- Couple : 320,97€
+          )
+        sinon
+          (
+            375,43€
+            + 54,47€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 248,89€
+            -- Couple : 298,58€
+          )
+        sinon
+          (
+            348,29€
+            + 49,71€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2019-09-30|
     et ancienneté_logement sous forme Neuf
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 372,52€
-              -- Couple : 449,41€
-            )
-          sinon
-            (
-              526,29€
-              + 76,87€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 332,44€
-              -- Couple : 400,13€
-            )
-          sinon
-            (
-              467,83€
-              + 67,68€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 310,36€
-              -- Couple : 372,15€
-            )
-          sinon
-            (
-              433,94€
-              + 61,79€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 372,52€
+            -- Couple : 449,41€
+          )
+        sinon
+          (
+            526,29€
+            + 76,87€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 332,44€
+            -- Couple : 400,13€
+          )
+        sinon
+          (
+            467,83€
+            + 67,68€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 310,36€
+            -- Couple : 372,15€
+          )
+        sinon
+          (
+            433,94€
+            + 61,79€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 
   étiquette petit_2
-  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt sous condition
+  définition calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
+  sous condition
     date_courante >= |2020-10-01|
     et date_signature_prêt >= |2019-09-30|
     et ancienneté_logement sous forme Ancien
     et type_prêt sous forme D331_63_64
   conséquence égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 299,86€
-              -- Couple : 361,87€
-            )
-          sinon
-            (
-              423,86€
-              + 62,01€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 267,30€
-              -- Couple : 321,93€
-            )
-          sinon
-            (
-              376,56€
-              + 54,63€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 249,64€
-              -- Couple : 299,48€
-            )
-          sinon
-            (
-              349,34€
-              + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 299,86€
+            -- Couple : 361,87€
+          )
+        sinon
+          (
+            423,86€
+            + 62,01€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 267,30€
+            -- Couple : 321,93€
+          )
+        sinon
+          (
+            376,56€
+            + 54,63€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 249,64€
+            -- Couple : 299,48€
+          )
+        sinon
+          (
+            349,34€
+            + 49,86€ * (décimal de (nombre_personnes_à_charge - 1))
+          )
+      )
+  )
 ```
 
 ### Article 19 | LEGIARTI000050286620
@@ -3281,7 +3331,7 @@ sont applicables aux prestations dues à compter du 1er octobre 2024.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
 
   étiquette base
   définition montant_forfaitaire_charges_d832_10 égal à
@@ -3295,7 +3345,7 @@ du même code est fixé à 5 euros.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d832_10 égal à 5€
 ```
@@ -3308,7 +3358,7 @@ est fixé à 10 euros.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_minimal_aide_d832_10 égal à 10€
 ```
@@ -3319,7 +3369,7 @@ Le coefficient « cm » défini au 3° de l'article D. 832-11 du même code est 
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition coefficient_multiplicateur_d832_11 égal à 22 111,33€
 ```
@@ -3336,7 +3386,7 @@ du contrat de prêt ou de location-accession est postérieure au 30 juin 1992 :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_limite_tranches_d832_15_1 égal à 5 600,85 €
   définition taux_tranche_inférieure_d832_15_1 égal à 20,80%
@@ -3351,7 +3401,7 @@ Dans le cas des copropriétaires prévus à l'article D. 832-16 du même code :
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   définition plafond_mensualité_d832_10_3
     état copropriétaires
   égal à
@@ -3371,10 +3421,10 @@ Majoration par personne à charge 13,60
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   exception base
-  définition montant_forfaitaire_charges_d832_10 sous condition
-    copropriété
+  définition montant_forfaitaire_charges_d832_10
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -3403,7 +3453,7 @@ b) 0,0234 pour les prêts souscrits à compter de cette dernière date.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition coefficient_multiplicateur_d832_17_3 égal à
     selon ancienneté_logement sous forme
@@ -3425,7 +3475,7 @@ D. 832-18 du même code est fixé à 16,25.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition coefficient_multiplicateur_d832_18 égal à 16,25
 ```
@@ -3454,98 +3504,98 @@ sont applicables aux prestations dues à compter du 1er octobre 2024.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   définition plafond_équivalence_loyer_éligible égal à
-    (
-      selon zone sous forme
-      -- Zone1 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 493,68 €
-              -- Couple : 578,74€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                617,10 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    666,42 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        703,89 €
-                      sinon
-                        (
-                          759,22 €
-                          + 78,75€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-      -- Zone2 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 451,45 €
-              -- Couple : 526,87€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                561,79 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    601,36 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        640,78 €
-                      sinon
-                        (
-                          682,79 €
-                          + 71,17 € * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-      -- Zone3 :
-        (
-          si nombre_personnes_à_charge = 0 alors
-            (
-              selon situation_familiale_calcul_apl sous forme
-              -- PersonneSeule : 428,52 €
-              -- Couple : 498,39€
-            )
-          sinon
-            (
-              si nombre_personnes_à_charge = 1 alors
-                528,76 €
-              sinon
-                (
-                  si nombre_personnes_à_charge = 2 alors
-                    563,66 €
-                  sinon
-                    (
-                      si nombre_personnes_à_charge = 3 alors
-                        598,54 €
-                      sinon
-                        (
-                          637,78 €
-                          + 66,05€ * (décimal de (nombre_personnes_à_charge - 4))
-                        )
-                    )
-                )
-            )
-        )
-    )
+  (
+    selon zone sous forme
+    -- Zone1 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 493,68 €
+            -- Couple : 578,74€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              617,10 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  666,42 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      703,89 €
+                    sinon
+                      (
+                        759,22 €
+                        + 78,75€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+    -- Zone2 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 451,45 €
+            -- Couple : 526,87€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              561,79 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  601,36 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      640,78 €
+                    sinon
+                      (
+                        682,79 €
+                        + 71,17 € * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+    -- Zone3 :
+      (
+        si nombre_personnes_à_charge = 0 alors
+          (
+            selon situation_familiale_calcul_apl sous forme
+            -- PersonneSeule : 428,52 €
+            -- Couple : 498,39€
+          )
+        sinon
+          (
+            si nombre_personnes_à_charge = 1 alors
+              528,76 €
+            sinon
+              (
+                si nombre_personnes_à_charge = 2 alors
+                  563,66 €
+                sinon
+                  (
+                    si nombre_personnes_à_charge = 3 alors
+                      598,54 €
+                    sinon
+                      (
+                        637,78 €
+                        + 66,05€ * (décimal de (nombre_personnes_à_charge - 4))
+                      )
+                  )
+              )
+          )
+      )
+  )
 ```
 
 ### Article 28 | LEGIARTI000039160781
@@ -3555,7 +3605,7 @@ du même code est fixé à 5 euros.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d832_24 égal à 5 €
 ```
@@ -3568,7 +3618,7 @@ est fixé à 10 euros.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_minimal_aide_d823_24 égal à 10 €
 ```
@@ -3582,7 +3632,7 @@ dans la formule de calcul du coefficient de prise en charge « K » sont fixées
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   # Attention par homogénéité de la formule du D832-25 il faut que cm soit
   # un montant d'argent.
@@ -3594,7 +3644,7 @@ respectivement au d du 1° et au c du 2°.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   # Attention par homogénéité de la formule du D832-25 il faut que cm soit
   # un montant d'argent.
@@ -3624,38 +3674,40 @@ a) Au premier alinéa :
 
 ```catala
 champ d'application CalculÉquivalenceLoyerMinimale
-  sous condition date_courante > |2019-10-01|:
+sous condition date_courante > |2019-10-01|:
   définition tranches_revenus_d832_26 égal à
-    [ TrancheRevenu {
+    [
+      TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 1948,10€
         -- bas: 0€
         -- taux: 4%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 2678,71€
         -- bas: 1948,10€
         -- taux: 10,40%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 3896,18€
         -- bas: 2678,71€
         -- taux: 21,60%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 5 357,44€
         -- bas: 3896,18€
         -- taux: 26,40%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 6 331,29€
         -- bas: 5 357,44€
         -- taux: 32%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Infini
         -- bas: 6 331,29€
         -- taux: 48%
-      } ]
+      }
+    ]
 ```
 
 b) Au deuxième alinéa :
@@ -3672,36 +3724,38 @@ b) Au deuxième alinéa :
 
 ```catala
 champ d'application CalculÉquivalenceLoyerMinimale
-  sous condition date_courante > |2019-10-01|:
+sous condition date_courante > |2019-10-01|:
   exception
-  définition tranches_revenus_d832_26 sous condition
-    condition_2_du_832_25
+  définition tranches_revenus_d832_26
+  sous condition condition_2_du_832_25
   conséquence égal à
-    [ TrancheRevenu {
+    [
+      TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 1423,03€
         -- bas: 0€
         -- taux: 0%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 2047,61€
         -- bas: 1423,03€
         -- taux: 2,40%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 2629,85€
         -- bas: 2047,61€
         -- taux: 20,80%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Revenu contenu 4095,05€
         -- bas: 2629,85€
         -- taux: 23,20%
-      } ;
+      };
       TrancheRevenu {
         -- haut: LimiteTranche.Infini
         -- bas: 4095,05€
         -- taux: 32,80%
-      } ]
+      }
+    ]
 ```
 
 II.-Les montants forfaitaires mentionnés aux premier et deuxième alinéas sont
@@ -3709,7 +3763,7 @@ fixés respectivement à 45,57 et 76,32.
 
 ```catala
 champ d'application CalculÉquivalenceLoyerMinimale
-  sous condition date_courante > |2019-10-01|:
+sous condition date_courante > |2019-10-01|:
   définition montant_forfaitaire_d832_26 égal à
     si condition_2_du_832_25 alors 76,32 € sinon 45,57 €
 ```
@@ -3742,7 +3796,7 @@ D. 832-25 du même code pour lesquels ce montant est fixé à 15 euros.
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d832_27 égal à
     si condition_2_du_832_25 alors 15 € sinon 26,68€
@@ -3939,12 +3993,11 @@ Certificats datés          I       314,76    379,33    407,87   419,27   431,06
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2020-01-01|:
+sous condition date_courante >= |2020-01-01|:
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |1992-07-01| et date_calcul < |1994-07-01|
+  sous condition date_calcul >= |1992-07-01| et date_calcul < |1994-07-01|
   conséquence égal à
     (
       selon zone sous forme
@@ -4001,8 +4054,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |1994-07-01| et date_calcul < |1997-07-01|
+  sous condition date_calcul >= |1994-07-01| et date_calcul < |1997-07-01|
   conséquence égal à
     (
       selon zone sous forme
@@ -4059,8 +4111,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |1997-07-01| et date_calcul < |1998-07-01|
+  sous condition date_calcul >= |1997-07-01| et date_calcul < |1998-07-01|
   conséquence égal à
     (
       selon zone sous forme
@@ -4117,8 +4168,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |1998-07-01| et date_calcul < |1999-07-01|
+  sous condition date_calcul >= |1998-07-01| et date_calcul < |1999-07-01|
   conséquence égal à
     (
       selon zone sous forme
@@ -4175,8 +4225,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |1999-07-01| et date_calcul < |2000-07-01|
+  sous condition date_calcul >= |1999-07-01| et date_calcul < |2000-07-01|
   conséquence égal à
     (
       selon zone sous forme
@@ -4196,7 +4245,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2404€
             + 209€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
         (
@@ -4214,7 +4263,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2307 €
             + 201€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone3 :
         (
@@ -4232,15 +4281,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2201€
             + 191€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
     )
     * taux_francs_vers_euros
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2000-07-01| et date_calcul < |2001-07-01|
+  sous condition date_calcul >= |2000-07-01| et date_calcul < |2001-07-01|
   conséquence égal à
     (
       selon zone sous forme
@@ -4260,7 +4308,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2428€
             + 211€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
         (
@@ -4278,7 +4326,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2330 €
             + 203€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone3 :
         (
@@ -4296,15 +4344,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2223€
             + 193€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
     )
     * taux_francs_vers_euros
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2001-07-01| et date_calcul < |2002-01-01|
+  sous condition date_calcul >= |2001-07-01| et date_calcul < |2002-01-01|
   conséquence égal à
     (
       selon zone sous forme
@@ -4324,7 +4371,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2457€
             + 214€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone2 :
         (
@@ -4342,7 +4389,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2358 €
             + 205€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
       -- Zone3 :
         (
@@ -4360,15 +4407,14 @@ champ d'application CalculAllocationLogementAccessionPropriété
           sinon
             2250€
             + 195€
-            * (décimal de (nombre_personnes_à_charge - 5))
+              * (décimal de (nombre_personnes_à_charge - 5))
         )
     )
     * taux_francs_vers_euros
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2002-01-01| et date_calcul < |2002-07-01|
+  sous condition date_calcul >= |2002-01-01| et date_calcul < |2002-07-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4387,7 +4433,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           374,57€
           + 32,62€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4405,7 +4451,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           359,47 €
           + 31,25€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4423,13 +4469,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           343,01€
           + 29,73€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2002-07-01| et date_calcul < |2003-07-01|
+  sous condition date_calcul >= |2002-07-01| et date_calcul < |2003-07-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4448,7 +4493,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           379,06€
           + 33,01€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4466,7 +4511,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           363,78 €
           + 31,63€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4484,13 +4529,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           347,13€
           + 30,09€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2003-07-01| et date_calcul < |2005-09-01|
+  sous condition date_calcul >= |2003-07-01| et date_calcul < |2005-09-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4509,7 +4553,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           383,61€
           + 33,41€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4527,7 +4571,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           368,15 €
           + 32,01€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4545,13 +4589,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           351,30€
           + 30,45€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2005-09-01| et date_calcul < |2007-01-01|
+  sous condition date_calcul >= |2005-09-01| et date_calcul < |2007-01-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4570,7 +4613,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           390,51€
           + 34,01€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4588,7 +4631,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           374,78 €
           + 32,59€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4606,13 +4649,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           357,62€
           + 31,00€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2007-01-01| et date_calcul < |2008-01-01|
+  sous condition date_calcul >= |2007-01-01| et date_calcul < |2008-01-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4631,7 +4673,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           401,44€
           + 34,96€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4649,7 +4691,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           385,27 €
           + 33,50€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4667,13 +4709,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           367,33€
           + 31,87€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2008-01-01| et date_calcul < |2009-01-01|
+  sous condition date_calcul >= |2008-01-01| et date_calcul < |2009-01-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4692,7 +4733,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           412,52€
           + 35,92€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4710,7 +4751,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           395,90 €
           + 34,42€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4728,13 +4769,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           377,78€
           + 32,75€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2009-01-01| et date_calcul < |2010-01-01|
+  sous condition date_calcul >= |2009-01-01| et date_calcul < |2010-01-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4753,7 +4793,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           424,69€
           + 36,98€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4771,7 +4811,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           407,58 €
           + 35,44€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4789,13 +4829,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           388,92€
           + 33,72€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2010-01-01| et date_calcul < |2011-01-01|
+  sous condition date_calcul >= |2010-01-01| et date_calcul < |2011-01-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4814,7 +4853,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           426,05€
           + 37,10€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4832,7 +4871,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           408,88 €
           + 35,55€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4850,13 +4889,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           390,16€
           + 33,83€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2011-01-01| et date_calcul < |2012-01-01|
+  sous condition date_calcul >= |2011-01-01| et date_calcul < |2012-01-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4875,7 +4913,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           430,74€
           + 37,51€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4893,7 +4931,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           413,38 €
           + 35,94€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4911,13 +4949,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           394,45€
           + 34,20€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2012-01-01| et date_calcul < |2013-01-01|
+  sous condition date_calcul >= |2012-01-01| et date_calcul < |2013-01-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4936,7 +4973,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           435,05€
           + 37,89€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -4954,7 +4991,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           417,51 €
           + 36,30€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -4972,13 +5009,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           398,39€
           + 34,54€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2013-01-01| et date_calcul < |2014-10-01|
+  sous condition date_calcul >= |2013-01-01| et date_calcul < |2014-10-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -4997,7 +5033,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           444,40€
           + 38,70€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -5015,7 +5051,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           426,59 €
           + 37,08€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -5033,13 +5069,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           406,96€
           + 35,28€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2014-10-01| et date_calcul < |2015-10-01|
+  sous condition date_calcul >= |2014-10-01| et date_calcul < |2015-10-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -5058,7 +5093,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           446,93€
           + 38,92€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -5076,7 +5111,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           428,92 €
           + 37,29€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -5094,13 +5129,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           409,28€
           + 35,48€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2015-10-01| et date_calcul < |2017-10-01|
+  sous condition date_calcul >= |2015-10-01| et date_calcul < |2017-10-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -5119,7 +5153,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           447,29€
           + 38,95€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -5137,7 +5171,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           429,26 €
           + 37,32€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -5155,13 +5189,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           409,61€
           + 35,51€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2017-10-01| et date_calcul < |2019-10-01|
+  sous condition date_calcul >= |2017-10-01| et date_calcul < |2019-10-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -5180,7 +5213,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           450,64€
           + 39,24€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -5198,7 +5231,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           432,48 €
           + 37,60€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -5216,13 +5249,12 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           412,68€
           + 35,78€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état base
-  sous condition
-    date_calcul >= |2019-10-01|
+  sous condition date_calcul >= |2019-10-01|
   conséquence égal à
     selon zone sous forme
     -- Zone1 :
@@ -5241,7 +5273,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           452,00€
           + 39,36€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone2 :
       (
@@ -5259,7 +5291,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           433,78 €
           + 37,71€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
     -- Zone3 :
       (
@@ -5277,7 +5309,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
         sinon
           413,92€
           + 35,88€
-          * (décimal de (nombre_personnes_à_charge - 5))
+            * (décimal de (nombre_personnes_à_charge - 5))
       )
 
   # Une exception est à venir avec l'article 37
@@ -5328,7 +5360,7 @@ sont applicables aux prestations dues à compter du 1er octobre 2024.
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges égal à
@@ -5346,7 +5378,7 @@ Le montant de minoration forfaitaire prévu au 9e alinéa de l'article D. 842-6 
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d842_6 égal à 5 €
 ```
@@ -5358,7 +5390,7 @@ contribution pour le remboursement de la dette sociale, est fixé à 10 euros.
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_minimal_aide_d842_6 égal à 10 €
 ```
@@ -5371,12 +5403,11 @@ Dans le cas des copropriétaires prévus à l'article D. 842-10 du même code :
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   exception
   définition calcul_plafond_mensualité_d842_6
     de date_calcul, nombre_personnes_à_charge état avec_copropriété
-  sous condition
-    copropriété
+  sous condition copropriété
   conséquence égal à
     (
       calcul_plafond_mensualité_d842_6 de
@@ -5396,10 +5427,10 @@ Majoration par personne à charge                         13,60
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
   étiquette copropriété exception base
-  définition montant_forfaitaire_charges sous condition
-    copropriété
+  définition montant_forfaitaire_charges
+  sous condition copropriété
   conséquence égal à
     (
       selon situation_familiale_calcul_apl sous forme
@@ -5422,7 +5453,7 @@ Pour le calcul de la dépense nette minimale de logement définie à l'article D
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d842_11 égal à 15 €
 ```
@@ -5431,7 +5462,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition coefficient_d842_11 égal à 0,0234
 ```
@@ -5444,7 +5475,7 @@ Pour déterminer le plancher de ressources défini à l'article D. 842-12 du mê
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition coefficient_d842_12 égal à 16,25
 ```
@@ -5453,7 +5484,7 @@ champ d'application CalculAllocationLogementAccessionPropriété
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d842_12 égal à 3 900 €
 ```
@@ -5477,7 +5508,7 @@ sont applicables aux prestations dues à compter du 1er octobre 2024.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2024-10-01|:
+sous condition date_courante >= |2024-10-01|:
 
   étiquette métropole
   définition multiplicateur_majoration_charges égal à
@@ -5496,7 +5527,7 @@ fixé à 5 euros.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_forfaitaire_d842_15 égal à 5 €
 ```
@@ -5509,7 +5540,7 @@ est fixé à 10 euros.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_minimal_aide_d842_15 égal à 10 €
 ```
@@ -5527,9 +5558,9 @@ b) 144,92 euros euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
+sous condition date_courante >= |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUS
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 93,07 €
@@ -5544,9 +5575,9 @@ b) 292,46 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
+sous condition date_courante >= |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme ÉtudiantLogéEnChambreCROUSRéhabilitée
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 188,17 €
@@ -5561,9 +5592,9 @@ b) 354,78 euros lorsqu'il s'agit d'un couple ;
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
+sous condition date_courante >= |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme PersonnesÂgéesSelon3DeD842_16
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 228,31 €
@@ -5578,9 +5609,9 @@ b) 292,46 euros lorsqu'il s'agit d'un couple.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2024-10-01|:
-  définition équivalence_loyer sous condition
-    catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
+sous condition date_courante >= |2024-10-01|:
+  définition équivalence_loyer
+  sous condition catégorie_équivalence_loyer_d842_16 sous forme AutresPersonnes
   conséquence égal à
     selon situation_familiale_calcul_apl sous forme
     -- PersonneSeule : 188,17 €
@@ -5599,7 +5630,7 @@ est fixé à 15 euros.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition montant_minimal_dépense_nette_d842_17 égal à 15 €
 ```
@@ -5616,17 +5647,19 @@ majoré de 20 % par enfant supplémentaire à charge.
 
 ```catala
 champ d'application ÉligibilitéPrimeDeDéménagement
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
   définition plafond_d823_22 égal à
     base_mensuelle_allocations_familiales.montant * 240%
     + (
-      si nombre de
+      si
+        nombre de
           (
             liste de personne_à_charge parmi ménage.personnes_à_charge
               tel que personne_à_charge sous forme EnfantÀCharge
           )
-        > 3 alors
+        > 3
+      alors
         base_mensuelle_allocations_familiales.montant
         * (
           décimal de
@@ -5665,9 +5698,10 @@ enfant à charge, est remplacée par " 8 656 euros " ;
 # locatif. Notamment le paramètre R0 est défini dans le calcul des APL,
 # pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5704,53 +5738,53 @@ Par personne supplémentaire à charge                10,36
 # locatif. Notamment le paramètre du montant des charges est défini dans le
 # calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   étiquette base_outre_mer exception base_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges_d823_16
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     40,26€ + 10,36€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   étiquette outre_mer exception copropriété
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     40,26 € + 10,36 € * multiplicateur_majoration_charges
 
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   exception base
-  définition montant_forfaitaire_charges sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition montant_forfaitaire_charges
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     40,26 € + 10,36 € * multiplicateur_majoration_charges
 ```
@@ -5774,9 +5808,10 @@ Majoration par personne à charge 10,36
 # locatif. Notamment le paramètre du montant des charges colocation est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   exception colocation_métropole
-  définition montant_forfaitaire_charges_d823_16 sous condition
+  définition montant_forfaitaire_charges_d823_16
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5797,9 +5832,10 @@ champ d'application CalculAidePersonnaliséeLogementLocatif
     + 10,36€ * multiplicateur_majoration_charges_d823_16
 
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   exception outre_mer
-  définition montant_forfaitaire_charges sous condition
+  définition montant_forfaitaire_charges
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5862,19 +5898,19 @@ Majoration par personne à charge supplémentaire     -0,06 %
 # locatif. Notamment le paramètre TF est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   exception base
-  définition taux_composition_familiale sous condition
-    (
-      selon résidence sous forme
-      -- Guadeloupe : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- SaintBarthélemy : vrai
-      -- SaintMartin : vrai
-      -- n'importe quel : faux
-    )
+  définition taux_composition_familiale
+  sous condition (
+    selon résidence sous forme
+    -- Guadeloupe : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- SaintBarthélemy : vrai
+    -- SaintMartin : vrai
+    -- n'importe quel : faux
+  )
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -5957,9 +5993,10 @@ compter du 1er janvier 2025.
 # locatif. Notamment le paramètre RO est défini
 # dans le calcul des APL pas celui des AL.
 champ d'application CalculAidePersonnaliséeLogementLocatif
-  sous condition date_courante >= |2025-01-01|:
+sous condition date_courante >= |2025-01-01|:
   exception métropole
-  définition abattement_forfaitaire_d823_17 sous condition
+  définition abattement_forfaitaire_d823_17
+  sous condition
     selon résidence sous forme
     -- SaintPierreEtMiquelon : vrai
     -- n'importe quel : faux
@@ -6012,10 +6049,10 @@ dérogation sont celles appartenant à la zone III.
 
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement
-  sous condition date_courante >= |2019-10-01|:
+sous condition date_courante >= |2019-10-01|:
   # Voir article 50
-  règle logement_situé_commune_déséquilibre_l831_2 sous condition
-    ménage.logement.zone sous forme Zone3
+  règle logement_situé_commune_déséquilibre_l831_2
+  sous condition ménage.logement.zone sous forme Zone3
   conséquence rempli
 ```
 

--- a/tests/fr/autres_codes.catala_fr.result
+++ b/tests/fr/autres_codes.catala_fr.result
@@ -21,7 +21,7 @@ personnelle au logement, il n'est pas pris en compte, comme enfant
 ```catala
 champ d'application PrestationsFamiliales:
   exception cas_base
-  règle droit_ouvert de enfant sous condition
-    enfant.bénéficie_titre_personnel_aide_personnelle_logement
+  règle droit_ouvert de enfant
+  sous condition enfant.bénéficie_titre_personnel_aide_personnelle_logement
   conséquence non rempli
 ```

--- a/tests/fr/autres_sources.catala_fr.result
+++ b/tests/fr/autres_sources.catala_fr.result
@@ -54,9 +54,10 @@ Couple marié   17 905,06 €    1 492,08 €
 # Uniquement la valeur du plafond individuel est important pour l'éligibilité
 # aux APL
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  définition plafond_individuel_l815_9_sécu sous condition
-    date_courante >= |2023-01-01|
-  conséquence égal à 11 533,02 €
+  définition plafond_individuel_l815_9_sécu
+  sous condition date_courante >= |2023-01-01|
+  conséquence égal à
+    11 533,02 €
 ```
 
 ## Circulaire de la CNAV 2022-3 du 11/01/2022 "Revalorisation à compter du 1er janvier 2022"
@@ -85,10 +86,12 @@ Couple marié   17 079,77 €    1 423,31 €
 # Uniquement la valeur du plafond individuel est important pour l'éligibilité
 # aux APL
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  définition plafond_individuel_l815_9_sécu sous condition
+  définition plafond_individuel_l815_9_sécu
+  sous condition
     date_courante >= |2022-01-01|
     et date_courante < |2023-01-01|
-  conséquence égal à 11 001,44€
+  conséquence égal à
+    11 001,44€
 ```
 
 ## Circulaire de la CNAV 2021-1 du 11/01/2021 "Revalorisation à compter du 1er janvier 2021"
@@ -117,10 +120,12 @@ Couple marié   16 893,94 €    1 407,82 €
 # Uniquement la valeur du plafond individuel est important pour l'éligibilité
 # aux APL
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  définition plafond_individuel_l815_9_sécu sous condition
+  définition plafond_individuel_l815_9_sécu
+  sous condition
     date_courante >= |2021-01-01|
     et date_courante < |2022-01-01|
-  conséquence égal à 10 881,75€
+  conséquence égal à
+    10 881,75€
 ```
 
 # Ordonnance n° 96-50 du 24 janvier 1996 relative au remboursement de la dette sociale
@@ -147,8 +152,8 @@ code de la construction et de l'habitation ;
 
 ```catala
 champ d'application ContributionsSocialesAidesPersonnelleLogement:
-  définition montant de aide_finale sous condition
-    date_courante >= |2018-09-01|
+  définition montant de aide_finale
+  sous condition date_courante >= |2018-09-01|
   conséquence égal à
     aide_finale * taux_crds
 
@@ -187,9 +192,10 @@ Le taux des contributions instituées par les articles 14 à 17 est fixé à 0,5
 
 ```catala
 champ d'application ContributionsSocialesAidesPersonnelleLogement:
-  définition taux_crds sous condition
-    date_courante >= |2020-01-01|
-  conséquence égal à 0,5%
+  définition taux_crds
+  sous condition date_courante >= |2020-01-01|
+  conséquence égal à
+    0,5%
 ```
 
 Le taux de la contribution instituée au I de l'article 18 est fixé à 2,2 %.
@@ -379,13 +385,16 @@ peuvent être modifiées par décret.
 ```catala
 déclaration montée_en_charge_saint_pierre_miquelon
   contenu argent
-  dépend de aide_finale contenu argent,
+  dépend de
+    aide_finale contenu argent,
     résidence contenu France.Collectivité,
     date_courante contenu date
   égal à
-    si résidence sous forme SaintPierreEtMiquelon
+    si
+      résidence sous forme SaintPierreEtMiquelon
       et date_courante >= |2022-01-01|
-      et date_courante <= |2025-12-31| alors
+      et date_courante <= |2025-12-31|
+    alors
       aide_finale
       * (
         1,0
@@ -488,10 +497,12 @@ II. – La collectivité fixe les règles applicables dans les matières suivant
 # territoires.
 champ d'application ContributionsSocialesAidesPersonnelleLogement:
   exception
-  définition montant de aide_finale sous condition
+  définition montant de aide_finale
+  sous condition
     date_courante >= |2007-02-22|
     et lieu sous forme SaintPierreEtMiquelon
-  conséquence égal à 0 €
+  conséquence égal à
+    0 €
 ```
 
 2° Régime douanier, à l'exclusion des prohibitions à l'importation et à

--- a/tests/fr/benefices_industriels_commerciaux.catala_fr.result
+++ b/tests/fr/benefices_industriels_commerciaux.catala_fr.result
@@ -321,12 +321,14 @@ champ d'application BénéficesIndustrielsCommerciaux2:
             résultat de Interface.BénéficesIndustrielsCommerciauxGénérauxDéclarant avec {
               -- revenus_imposables_micro_marchandises: 30 000 €
               -- revenus_exceptionnels_ou_différés:
-                [ IR.RevenuExceptionnelOuDifféré {
+                [
+                  IR.RevenuExceptionnelOuDifféré {
                     -- valeur: 40 000 €
                     -- régime: Article163_0_A
                     -- échéance: RevenuExceptionnel
                     -- catégorie: MicroBénéficesIndustrielsCommerciauxLocationsMeubléesRuralesSpéciales
-                  } ]
+                  }
+                ]
             }
           ).sortie
         -- locations_meublées_micro_général: 25 000 €
@@ -615,12 +617,14 @@ champ d'application BénéficesIndustrielsCommerciaux3:
               -- revenus_imposables_micro_marchandises: 43 789€
               -- revenus_imposables_micro_services: 9 888€
               -- revenus_exceptionnels_ou_différés:
-                [ IR.RevenuExceptionnelOuDifféré {
+                [
+                  IR.RevenuExceptionnelOuDifféré {
                     -- valeur: 57843 €
                     -- régime: Article163_0_A
                     -- échéance: RevenuExceptionnel
                     -- catégorie: MicroBénéficesIndustrielsCommerciauxServices
-                  } ]
+                  }
+                ]
             }
           ).sortie
         -- locations_meublées_micro_général: 645€

--- a/tests/fr/benefices_non_commerciaux.catala_fr.result
+++ b/tests/fr/benefices_non_commerciaux.catala_fr.result
@@ -158,7 +158,7 @@ champ d'application BénéficesNonCommerciaux1:
   définition sortie égal à
     résultat de IR.BénéficesNonCommerciauxFoyerFiscal avec {
       -- déficits_réels_années_antérieures_non_professionnels: []
-      -- revenus: [ déclarant1.sortie ; déclarant2.sortie ]
+      -- revenus: [ déclarant1.sortie; déclarant2.sortie ]
       -- année_revenus: 2022
     }
 ```
@@ -308,18 +308,20 @@ champ d'application BénéficesNonCommerciaux2:
   définition sortie égal à
     résultat de IR.BénéficesNonCommerciauxFoyerFiscal avec {
       -- déficits_réels_années_antérieures_non_professionnels:
-        [ Oracles.DéficitAntérieur {
+        [
+          Oracles.DéficitAntérieur {
             -- année: 2019
             -- valeur: 5000 €
-          } ;
+          };
           Oracles.DéficitAntérieur {
             -- année: 2020
             -- valeur: 2000 €
-          } ;
+          };
           Oracles.DéficitAntérieur {
             -- année: 2021
             -- valeur: 15 000 €
-          } ]
+          }
+        ]
       -- revenus: [ déclarant1.sortie ]
       -- année_revenus: 2022
     }
@@ -578,15 +580,17 @@ champ d'application BénéficesNonCommerciaux3:
   définition sortie égal à
     résultat de IR.BénéficesNonCommerciauxFoyerFiscal avec {
       -- déficits_réels_années_antérieures_non_professionnels:
-        [ Oracles.DéficitAntérieur {
+        [
+          Oracles.DéficitAntérieur {
             -- année: 2020
             -- valeur: 1 000 €
-          } ;
+          };
           Oracles.DéficitAntérieur {
             -- année: 2021
             -- valeur: 25 000 €
-          } ]
-      -- revenus: [ déclarant1.sortie ; déclarant2.sortie ; déclarant3.sortie ]
+          }
+        ]
+      -- revenus: [ déclarant1.sortie; déclarant2.sortie; déclarant3.sortie ]
       -- année_revenus: 2022
     }
 ```

--- a/tests/fr/cgi_revenus.catala_fr.result
+++ b/tests/fr/cgi_revenus.catala_fr.result
@@ -116,8 +116,8 @@ champ d'application TraitementsSalairesFoyerFiscal:
     solde_revenu_brut_global_hors_quotient_avant_déficit_quotient
   égal à
     (
-      somme argent
-        de transforme chaque résultats
+      somme argent de
+      transforme chaque résultats
       parmi déclarations_avec_résultats_traitements_salaires en
         résultats.revenu_brut_déclarant_hors_quotient
     )
@@ -181,14 +181,14 @@ champ d'application BénéficesNonCommerciauxFoyerFiscal:
   définition solde_net_global_non_professionnel
     état agrégation
   égal à
-    somme argent
-      de transforme chaque résultat_liquidation
+    somme argent de
+    transforme chaque résultat_liquidation
     parmi résultats_liquidation_bénéfices_non_commerciaux en
       résultat_liquidation.solde_net_non_professionnel
 
   définition solde_net_global_professionnel égal à
-    somme argent
-      de transforme chaque résultat_liquidation
+    somme argent de
+    transforme chaque résultat_liquidation
     parmi résultats_liquidation_bénéfices_non_commerciaux en
       résultat_liquidation.solde_net_professionnel
 
@@ -214,22 +214,22 @@ champ d'application BénéficesIndustrielsCommerciauxFoyerFiscal:
   définition solde_net_global_non_professionnel_hors_locations_meublées
     état agrégation
   égal à
-    somme argent
-      de transforme chaque résultat_liquidation
+    somme argent de
+    transforme chaque résultat_liquidation
     parmi résultats_liquidation_bénéfices_industriels_commerciaux en
       résultat_liquidation.solde_net_non_professionnel_hors_locations_meublées
 
   définition solde_net_global_professionnel égal à
-    somme argent
-      de transforme chaque résultat_liquidation
+    somme argent de
+    transforme chaque résultat_liquidation
     parmi résultats_liquidation_bénéfices_industriels_commerciaux en
       résultat_liquidation.solde_net_professionnel
 
   définition solde_net_global_non_professionnel_locations_meublées
     état agrégation
   égal à
-    somme argent
-      de transforme chaque résultat_liquidation
+    somme argent de
+    transforme chaque résultat_liquidation
     parmi résultats_liquidation_bénéfices_industriels_commerciaux en
       résultat_liquidation.solde_net_non_professionnel_locations_meublées
 
@@ -243,7 +243,7 @@ champ d'application BénéficesIndustrielsCommerciauxFoyerFiscal:
     # non-professionnels.
     plancher de (solde_net_global_professionnel, 0 €)
     + plancher de
-      (solde_net_global_non_professionnel_hors_locations_meublées, 0 €)
+        (solde_net_global_non_professionnel_hors_locations_meublées, 0 €)
     + plancher de (solde_net_global_non_professionnel_locations_meublées, 0 €)
 ```
 
@@ -489,26 +489,26 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
   égal à
     solde_net_professionnel
     + (
-      résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
-        -- plus_values_nettes:
-          revenus.professionnels.plus_values_nettes_court_terme_micro
-        -- moins_values_nettes:
-          revenus.professionnels.moins_values_nettes_court_terme_micro
-      }
-    ).solde_net
+        résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
+          -- plus_values_nettes:
+            revenus.professionnels.plus_values_nettes_court_terme_micro
+          -- moins_values_nettes:
+            revenus.professionnels.moins_values_nettes_court_terme_micro
+        }
+      ).solde_net
 
   définition solde_net_non_professionnel_hors_locations_meublées
     état plus_moins_value_court_terme_micro
   égal à
     solde_net_non_professionnel_hors_locations_meublées
     + (
-      résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
-        -- plus_values_nettes:
-          revenus.non_professionnels.généraux.plus_values_nettes_court_terme_micro
-        -- moins_values_nettes:
-          revenus.non_professionnels.généraux.moins_values_nettes_court_terme_micro
-      }
-    ).solde_net
+        résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
+          -- plus_values_nettes:
+            revenus.non_professionnels.généraux.plus_values_nettes_court_terme_micro
+          -- moins_values_nettes:
+            revenus.non_professionnels.généraux.moins_values_nettes_court_terme_micro
+        }
+      ).solde_net
 ```
 
 ########## Article 39 quindecies | LEGIARTI000036428314
@@ -549,14 +549,14 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
     # les plus-values nettes à court terme sont comprises dans le revenu
     # imposable et par conséquent ne font pas l'objet du prélèvement libératoire
     # à 12,8%. Elles sont donc omises ci-dessous.
-    (
-      résultat de PrélèvementPlusMoinsValueLongTermeBénéficesIndustrielsCommerciaux avec {
-        -- plus_values_nettes:
-          revenus.non_professionnels.généraux.plus_values_nettes_long_terme_réel
-          + revenus.professionnels.plus_values_nettes_long_terme_réel
-        -- moins_values_nettes: 0 €
-      }
-    ).prélèvement_libératoire
+      (
+        résultat de PrélèvementPlusMoinsValueLongTermeBénéficesIndustrielsCommerciaux avec {
+          -- plus_values_nettes:
+            revenus.non_professionnels.généraux.plus_values_nettes_long_terme_réel
+            + revenus.professionnels.plus_values_nettes_long_terme_réel
+          -- moins_values_nettes: 0 €
+        }
+      ).prélèvement_libératoire
 
 # D'après BOI-BNC-BASE-30-30-10 paragraphe 150, ce prélèvement libératoire
 # s'applique aussi aux plus-values nettes à long terme des bénéfices non
@@ -574,12 +574,12 @@ champ d'application BénéficesNonCommerciauxDéclarant:
       }
     ).prélèvement_libératoire
     + (
-      résultat de PrélèvementPlusMoinsValueLongTermeBénéficesIndustrielsCommerciaux avec {
-        -- plus_values_nettes:
-          revenus.non_professionnels.généraux.plus_values_nettes_long_terme_réel
-        -- moins_values_nettes: 0 €
-      }
-    ).prélèvement_libératoire
+        résultat de PrélèvementPlusMoinsValueLongTermeBénéficesIndustrielsCommerciaux avec {
+          -- plus_values_nettes:
+            revenus.non_professionnels.généraux.plus_values_nettes_long_terme_réel
+          -- moins_values_nettes: 0 €
+        }
+      ).prélèvement_libératoire
 ```
 
 Il s'entend de l'excédent de ces plus-values sur les moins-values de même nature
@@ -856,7 +856,7 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
     soit abattement_total égal à abattement_forfaitaire_micro_total_marchandises état arrondissement
     + abattement_forfaitaire_micro_total_services état arrondissement
     + abattement_spécial_micro_total_location_meublées_rurales_spéciales
-      état arrondissement
+        état arrondissement
     dans
     # Ici, nous plafonnons l'abattement minimal par le montant des revenus micro
     # pour marchandises et services car ces revenus évalués forfaitairement ne
@@ -947,15 +947,15 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
   définition assiette_abattement_forfaitaire_micro_marchandises égal à
     revenus.professionnels.revenus_imposables_micro_marchandises
     + (
-      somme argent
-        de transforme chaque revenu_exceptionnel_ou_différé
+      somme argent de
+      transforme chaque revenu_exceptionnel_ou_différé
       parmi revenus_exceptionnels_professionnels_abattement_micro_marchandises en
         revenu_exceptionnel_ou_différé.valeur
     )
     + revenus.non_professionnels.généraux.revenus_imposables_micro_marchandises
     + (
-      somme argent
-        de transforme chaque revenu_exceptionnel_ou_différé
+      somme argent de
+      transforme chaque revenu_exceptionnel_ou_différé
       parmi revenus_exceptionnels_non_professionnels_abattement_micro_marchandises en
         revenu_exceptionnel_ou_différé.valeur
     )
@@ -1048,8 +1048,8 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
   définition assiette_abattement_forfaitaire_micro_services égal à
     revenus.professionnels.revenus_imposables_micro_services
     + (
-      somme argent
-        de transforme chaque revenu_exceptionnel_ou_différé
+      somme argent de
+      transforme chaque revenu_exceptionnel_ou_différé
       parmi revenus_exceptionnels_professionnels_abattement_micro_services en
         revenu_exceptionnel_ou_différé.valeur
     )
@@ -1130,8 +1130,8 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
     revenus.non_professionnels.locations_meublées_micro_classées_rurales_spéciales
     + revenus.non_professionnels.locations_meublées_micro_cotisations_classées_rurales_spéciales
     + somme argent de transforme chaque revenu_exceptionnel_ou_différé
-    parmi revenus_exceptionnels_non_professionnels_locations_meublées_rurales_spéciales en
-      revenu_exceptionnel_ou_différé.valeur
+      parmi revenus_exceptionnels_non_professionnels_locations_meublées_rurales_spéciales en
+        revenu_exceptionnel_ou_différé.valeur
 
   # L'assiette de cet abattement ne comprend pas les revenus de locations
   # meublées professionnelles qui pourrait également rentrer dans le régime
@@ -1355,26 +1355,28 @@ champ d'application TraitementsSalairesDéclarant:
   définition pensions_retraites_rentes_79
     état art79
   égal à
-    [ PensionRetraiteRente {
+    [
+      PensionRetraiteRente {
         -- valeur_initiale: revenus.pensions_retraites_rentes
         -- type_pension: TypePensionRetraiteRente.PensionsRetraitesRentes
-      } ;
+      };
       PensionRetraiteRente {
         -- valeur_initiale: revenus.pensions_retraites_en_capital_7_5pct
         -- type_pension: PensionEnCapital_7_5pct
-      } ;
+      };
       PensionRetraiteRente {
         -- valeur_initiale: revenus.pensions_en_capital_plans_épargne_retraite
         -- type_pension: PensionEnCapitalPlansÉpargneRetraite
-      } ;
+      };
       PensionRetraiteRente {
         -- valeur_initiale: revenus.pensions_invalidité
         -- type_pension: PensionInvalidité
-      } ;
+      };
       PensionRetraiteRente {
         -- valeur_initiale: revenus.pensions_alimentaires_perçues
         -- type_pension: PensionAlimentairePercue
-      } ]
+      }
+    ]
 # Ici on conserve une collection plutôt de calculer la somme, car les différents
 # types d'entrées vont nécessiter des calculs d'abattements différents par la
 # suite
@@ -1681,7 +1683,7 @@ champ d'application TraitementsSalairesDéclarant:
     traitements_salaires_avec_déduction_frais_professionnels
     + revenus.gains_et_distributions_carried_interest
     + revenus.
-      gains_et_distributions_carried_interest_soumis_contribution_salariale
+        gains_et_distributions_carried_interest_soumis_contribution_salariale
 # Ici gains_et_distributions_carried_interest_soumis_contribution_salariale
 # font partie du revenu brut global mais ils seront aussi soumis à un
 # certain type de prélèvement social prévu à l'article L137-18 du code
@@ -2151,8 +2153,8 @@ champ d'application TraitementsSalairesDéclarant:
     état art_81_quater
   égal à
     revenus.heures_supplémentaires_et_rtt_exonérées
-  définition exonérations_81_quater sous condition
-    année_revenus >= 2022
+  définition exonérations_81_quater
+  sous condition année_revenus >= 2022
   conséquence égal à
     plafond de assiette_exonérations_81_quater, 7500€
   # Ce plafond n'est pas systématiquement revu chaque année donc pas de date
@@ -2349,8 +2351,8 @@ champ d'application TraitementsSalairesDéclarant:
     état non_plafonnée_83_3_2
   égal à
     (
-      somme argent
-        de transforme chaque r_quotienté parmi revenus.revenus_exceptionnels_ou_différés en
+      somme argent de
+      transforme chaque r_quotienté parmi revenus.revenus_exceptionnels_ou_différés en
         (
           selon r_quotienté.catégorie sous forme
           -- TraitementsSalaires :
@@ -2364,14 +2366,17 @@ champ d'application TraitementsSalairesDéclarant:
   définition déduction_frais_professionnels_totale
     état plafonnée_83_3_2
   égal à
-    si déduction_frais_professionnels_totale
-      >= plafond_déduction_frais_professionnels alors
+    si
+      déduction_frais_professionnels_totale
+      >= plafond_déduction_frais_professionnels
+    alors
       plafond_déduction_frais_professionnels
     sinon déduction_frais_professionnels_totale
 
-  définition plafond_déduction_frais_professionnels sous condition
-    année_revenus = 2023
-  conséquence égal à 14 171 €
+  définition plafond_déduction_frais_professionnels
+  sous condition année_revenus = 2023
+  conséquence égal à
+    14 171 €
 
   # Enfin, on déduit le montant de la déduction pour les traitements et
   # salaires en faisant le solde des déductions déjà accordées pour
@@ -2384,11 +2389,11 @@ champ d'application TraitementsSalairesDéclarant:
     # de calcul où l'on applique les frais réels.
     déduction_frais_professionnels_totale
     - somme argent de transforme chaque r_quotienté parmi revenus_quotientés en
-      (
-        selon r_quotienté.catégorie sous forme
-        -- TraitementsSalaires : r_quotienté.déduction
-        -- n'importe quel : 0€
-      )
+        (
+          selon r_quotienté.catégorie sous forme
+          -- TraitementsSalaires : r_quotienté.déduction
+          -- n'importe quel : 0€
+        )
 ```
 
 Le montant de la déduction forfaitaire pour frais professionnels ne peut être inférieur à 495 €,
@@ -2410,8 +2415,10 @@ champ d'application TraitementsSalairesDéclarant:
   définition déduction_frais_professionnels_traitements_salaires_avant_prorata
     état plancher_83_3_3
   égal à
-    si déduction_frais_professionnels_traitements_salaires_avant_prorata
-      < minimum_déduction_frais_professionnels alors
+    si
+      déduction_frais_professionnels_traitements_salaires_avant_prorata
+      < minimum_déduction_frais_professionnels
+    alors
       # Ici nous allons maximiser la déduction des frais professionnels par le
       # "montant brut des traitements et salaires". Selon BOI-RSA-BASE-30-50-20,
       # paragraphe 40, il faut néanmoins défalcquer à ce montant brut les
@@ -2420,17 +2427,21 @@ champ d'application TraitementsSalairesDéclarant:
       # 154 quinquies du CGI". Au final, ce montant "brut" désigne en fait le
       # montant déclaré par le contribuable sur sa déclaration, comme exemplifié
       # par BOI-RSA-BASE-30-50-20, paragraphe 100.
-      si minimum_déduction_frais_professionnels
-        > traitements_salaires_avec_déduction_frais_professionnels alors
+      si
+        minimum_déduction_frais_professionnels
+        > traitements_salaires_avec_déduction_frais_professionnels
+      alors
         traitements_salaires_avec_déduction_frais_professionnels
       sinon minimum_déduction_frais_professionnels
     sinon déduction_frais_professionnels_traitements_salaires_avant_prorata
 
-  définition minimum_déduction_frais_professionnels sous condition
+  définition minimum_déduction_frais_professionnels
+  sous condition
     # Ici la valeur de 495 € est implicitement valable pour 2023 comme le
     # plafond précédent
     année_revenus = 2023
-  conséquence égal à 495 €
+  conséquence égal à
+    495 €
 ```
 
 La somme figurant au troisième alinéa est révisée chaque année dans la même proportion que la
@@ -2513,18 +2524,20 @@ champ d'application TraitementsSalairesDéclarant:
       # si le montant des frais réels est inférieur à la déduction
       # forfaitaire, alors on applique quand même cette dernière même
       # si le contribuable a coché la case frais réels.
-      si montant_frais_réels
-        < déduction_frais_professionnels_totale état plafonnée_83_3_2 alors
+      si
+        montant_frais_réels
+        < déduction_frais_professionnels_totale état plafonnée_83_3_2
+      alors
         FraisRéels.Non
       sinon
         FraisRéels.Oui contenu montant_frais_réels
 
   définition déduction_frais_professionnels_totale
     état plafonnée_83_3_2_avec_frais_réels
-  # D'après
-  # https://www.impots.gouv.fr/particulier/questions/en-formation-non-remuneree-puis-je-deduire-les-frais-reels,
-  # les frais réels peuvent créer un déficit de revenus donc ici on ne met pas
-  # de limite au montant de frais réels pour le calcul de la déduction.
+    # D'après
+    # https://www.impots.gouv.fr/particulier/questions/en-formation-non-remuneree-puis-je-deduire-les-frais-reels,
+    # les frais réels peuvent créer un déficit de revenus donc ici on ne met pas
+    # de limite au montant de frais réels pour le calcul de la déduction.
   égal à
     selon application_frais_réels sous forme
     -- FraisRéels.Non :
@@ -2545,8 +2558,7 @@ champ d'application TraitementsSalairesDéclarant:
   exception
   définition calcul_déduction_proratisée_revenus_quotientés_traitements_salaires
     de revenu_quotienté état base
-  sous condition
-    application_frais_réels sous forme FraisRéels.Oui
+  sous condition application_frais_réels sous forme FraisRéels.Oui
   conséquence égal à
     selon application_frais_réels sous forme
     -- FraisRéels.Non : 0 € # Ne peut pas arriver
@@ -2560,15 +2572,15 @@ champ d'application TraitementsSalairesDéclarant:
         revenu_quotienté
         / (
           traitements_salaires_avec_déduction_frais_professionnels
-          + somme argent
-            de transforme chaque autre_revenu_quotienté
-          parmi revenus.revenus_exceptionnels_ou_différés en
-            (
-              selon autre_revenu_quotienté.catégorie sous forme
-              -- CatégorieRevenuExceptionnelOuDifféré.TraitementsSalaires :
-                autre_revenu_quotienté.valeur
-              -- n'importe quel : 0 €
-            )
+          + somme argent de
+            transforme chaque autre_revenu_quotienté
+            parmi revenus.revenus_exceptionnels_ou_différés en
+              (
+                selon autre_revenu_quotienté.catégorie sous forme
+                -- CatégorieRevenuExceptionnelOuDifféré.TraitementsSalaires :
+                  autre_revenu_quotienté.valeur
+                -- n'importe quel : 0 €
+              )
         )
       )
       dans
@@ -2979,8 +2991,8 @@ champ d'application BénéficesNonCommerciauxDéclarant:
     + (somme argent de transforme chaque revenu parmi revenus_exceptionnels_professionnels_abattement_micro en revenu.valeur)
     + revenus.non_professionnels.généraux.revenus_imposables_micro
     + somme argent de transforme chaque revenu
-    parmi revenus_exceptionnels_non_professionnels_abattement_micro en
-      revenu.valeur
+      parmi revenus_exceptionnels_non_professionnels_abattement_micro en
+        revenu.valeur
 
   définition abattement_forfaitaire_micro_total
     état base
@@ -3033,26 +3045,26 @@ champ d'application BénéficesNonCommerciauxDéclarant:
   égal à
     solde_net_professionnel
     + (
-      résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
-        -- plus_values_nettes:
-          revenus.professionnels.généraux.plus_values_nettes_court_terme_micro
-        -- moins_values_nettes:
-          revenus.professionnels.généraux.moins_values_nettes_court_terme_micro
-      }
-    ).solde_net
+        résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
+          -- plus_values_nettes:
+            revenus.professionnels.généraux.plus_values_nettes_court_terme_micro
+          -- moins_values_nettes:
+            revenus.professionnels.généraux.moins_values_nettes_court_terme_micro
+        }
+      ).solde_net
 
   définition solde_net_non_professionnel
     état plus_moins_value_court_terme_micro
   égal à
     solde_net_non_professionnel
     + (
-      résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
-        -- plus_values_nettes:
-          revenus.non_professionnels.généraux.plus_values_nettes_court_terme_micro
-        -- moins_values_nettes:
-          revenus.non_professionnels.généraux.moins_values_nettes_court_terme_micro
-      }
-    ).solde_net
+        résultat de PlusMoinsValueCourtTermeBénéficesIndustrielsCommerciaux avec {
+          -- plus_values_nettes:
+            revenus.non_professionnels.généraux.plus_values_nettes_court_terme_micro
+          -- moins_values_nettes:
+            revenus.non_professionnels.généraux.moins_values_nettes_court_terme_micro
+        }
+      ).solde_net
 ```
 
 Le premier seuil mentionné au premier alinéa est actualisé tous les trois ans
@@ -3184,8 +3196,8 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
   égal à
     prélèvement_libératoire_auto_entreprise
     + revenus.
-      chiffre_affaires_prélèvement_libératoire_services_éxonéré_cotisations
-    * 1,7%
+        chiffre_affaires_prélèvement_libératoire_services_éxonéré_cotisations
+      * 1,7%
 ```
 
 3° 2,2 % pour les contribuables soumis au régime défini à l'article 102 ter et
@@ -3380,8 +3392,8 @@ champ d'application ImputationDéficitSurRevenusQuotientés:
   # quotients au global prenant également les revenus au quotients nettement
   # négatifs ? [Denis : normalement pas de revenu négatif...]
   définition base_d_imputation_déficit_catégoriel égal à
-    somme argent
-      de transforme chaque revenus_quotientés_catégoriels_déclarant
+    somme argent de
+    transforme chaque revenus_quotientés_catégoriels_déclarant
     parmi revenus_quotientés_catégoriels en
       (
         somme argent de transforme chaque revenu_quotienté_catégoriel
@@ -3585,7 +3597,7 @@ champ d'application BénéficesIndustrielsCommerciauxFoyerFiscal:
     # pour réduire la valeur absolue du nombre négatif de départ.
     solde_net_global_non_professionnel_hors_locations_meublées
     + imputation_déficit_sur_revenu_quotientés_non_professionnels.
-      déficit_catégoriel_imputé
+        déficit_catégoriel_imputé
 
   définition imputation_aux_déficits_les_plus_anciens.revenu_déclaré égal à
     solde_net_global_non_professionnel_hors_locations_meublées
@@ -3594,10 +3606,10 @@ champ d'application BénéficesIndustrielsCommerciauxFoyerFiscal:
   définition
     imputation_aux_déficits_les_plus_anciens.déficits_antérieurs
   égal à
-    (
-      liste de déficit parmi déficits_réels_années_antérieures_non_professionnels
-        tel que déficit.année >= année_revenus - 6
-    )
+  (
+    liste de déficit parmi déficits_réels_années_antérieures_non_professionnels
+      tel que déficit.année >= année_revenus - 6
+  )
 
   définition
     déficits_réels_années_antérieures_non_professionnels_mis_à_jour
@@ -3686,7 +3698,7 @@ champ d'application BénéficesIndustrielsCommerciauxFoyerFiscal:
     # nombre positif pour réduire la valeur absolue du nombre négatif de départ.
     solde_net_global_non_professionnel_locations_meublées
     + imputation_déficit_sur_revenu_quotientés_non_professionnels_locations_meublées.
-      déficit_catégoriel_imputé
+        déficit_catégoriel_imputé
 
   définition
     imputation_aux_déficits_les_plus_anciens_locations_meublées.revenu_déclaré
@@ -3697,10 +3709,10 @@ champ d'application BénéficesIndustrielsCommerciauxFoyerFiscal:
   définition
     imputation_aux_déficits_les_plus_anciens_locations_meublées.déficits_antérieurs
   égal à
-    (
-      liste de déficit parmi déficits_réels_années_antérieures_non_professionnels_locations_meublées
-        tel que déficit.année >= année_revenus - 10
-    )
+  (
+    liste de déficit parmi déficits_réels_années_antérieures_non_professionnels_locations_meublées
+      tel que déficit.année >= année_revenus - 10
+  )
 
   définition
     déficits_réels_années_antérieures_non_professionnels_locations_meublées_mis_à_jour
@@ -3763,7 +3775,7 @@ champ d'application BénéficesNonCommerciauxFoyerFiscal:
     # pour réduire la valeur absolue du nombre négatif de départ.
     solde_net_global_non_professionnel
     + imputation_déficit_sur_revenu_quotientés_non_professionnels.
-      déficit_catégoriel_imputé
+        déficit_catégoriel_imputé
 
   définition imputation_aux_déficits_les_plus_anciens.revenu_déclaré égal à
     solde_net_global_non_professionnel état imputation_déficit_revenus_quotient
@@ -3771,10 +3783,10 @@ champ d'application BénéficesNonCommerciauxFoyerFiscal:
   définition
     imputation_aux_déficits_les_plus_anciens.déficits_antérieurs
   égal à
-    (
-      liste de déficit parmi déficits_réels_années_antérieures_non_professionnels
-        tel que déficit.année >= année_revenus - 6
-    )
+  (
+    liste de déficit parmi déficits_réels_années_antérieures_non_professionnels
+      tel que déficit.année >= année_revenus - 6
+  )
 
   définition
     déficits_réels_années_antérieures_non_professionnels_mis_à_jour
@@ -4125,13 +4137,14 @@ champ d'application TraitementsSalairesFoyerFiscal:
   # Nous définissons le plafond dans le champ d'application au niveau
   # du foyer fiscal et non de l'individu car ce plafond s'applique bien
   # au niveau du foyer fiscal et non de l'individu.
-  définition plafond_abattement_pensions_retraites_rentes sous condition
-    année_revenus = 2023
-  # Ici, l'année des revenus est soumis à ce plafond est 2022 car le montant
-  # du plafond est remis à jour pour le millésime (N-1) en mai de l'année N
-  # suivant les évolutions du barème de l'IR votées à la fin de l'année (N-1)
-  # pour le millésime (N-1).
-  conséquence égal à 4 321€
+  définition plafond_abattement_pensions_retraites_rentes
+  sous condition année_revenus = 2023
+    # Ici, l'année des revenus est soumis à ce plafond est 2022 car le montant
+    # du plafond est remis à jour pour le millésime (N-1) en mai de l'année N
+    # suivant les évolutions du barème de l'IR votées à la fin de l'année (N-1)
+    # pour le millésime (N-1).
+  conséquence égal à
+    4 321€
 
 champ d'application TraitementsSalairesDéclarant:
   # D'après un exemple donné par BOI-RSA-PENS-30-10-10, paragraphe 180,
@@ -4157,12 +4170,12 @@ champ d'application TraitementsSalairesDéclarant:
         sinon 0 €
     )
     + somme argent de (
-      transforme chaque r_quotienté parmi revenus.revenus_exceptionnels_ou_différés en
-        selon r_quotienté.catégorie sous forme
-        -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes :
-          calcul_abattement_pensions_retraites_rentes de r_quotienté.valeur
-        -- n'importe quel : 0 €
-    )
+        transforme chaque r_quotienté parmi revenus.revenus_exceptionnels_ou_différés en
+          selon r_quotienté.catégorie sous forme
+          -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes :
+            calcul_abattement_pensions_retraites_rentes de r_quotienté.valeur
+          -- n'importe quel : 0 €
+      )
 
   # Comment coder la cumulativité du plafond d'abbattement au global sur toutes
   # les pensions et retraites du foyer fiscal ? On pourrait sommer les
@@ -4203,8 +4216,8 @@ champ d'application TraitementsSalairesDéclarant:
   égal à
     abattement_pensions_retraites_rentes_total_plafonné
     - (
-      somme argent
-        de transforme chaque r_quotienté parmi revenus_quotientés en
+      somme argent de
+      transforme chaque r_quotienté parmi revenus_quotientés en
         (
           selon r_quotienté.catégorie sous forme
           -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes :
@@ -4217,31 +4230,33 @@ champ d'application TraitementsSalairesDéclarant:
 # sur l'ensemble du foyer fiscal.
 champ d'application TraitementsSalairesFoyerFiscal:
   définition résultats_liquidations_plafond_pensions_retraites_rentes égal à
-    (
-      transforme chaque déclaration_revenus parmi déclarations_revenus en
-        soit résultats_liquidation égal à
-          résultat de TraitementsSalairesDéclarant avec {
-          # La première liquidation se fait en déplafonnant l'abattement!
-          -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné -- revenus: déclaration_revenus -- année_revenus: année_revenus }
-        dans
-        RésultatsLiquidationPlafondPensionRetraitesRentes {
-          -- abattement_pensions_retraites_rentes:
-            résultats_liquidation.abattement_pensions_retraites_rentes
-          -- revenus: déclaration_revenus
-        }
-    )
+  (
+    transforme chaque déclaration_revenus parmi déclarations_revenus en
+      soit résultats_liquidation égal à
+        résultat de TraitementsSalairesDéclarant avec {
+        # La première liquidation se fait en déplafonnant l'abattement!
+        -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné -- revenus: déclaration_revenus -- année_revenus: année_revenus }
+      dans
+      RésultatsLiquidationPlafondPensionRetraitesRentes {
+        -- abattement_pensions_retraites_rentes:
+          résultats_liquidation.abattement_pensions_retraites_rentes
+        -- revenus: déclaration_revenus
+      }
+  )
 
   # Une fois la liquidation faite, nous pouvons aggréger les abattements
   # sur tout le foyer fiscal.
   définition abbattement_total_déplafonné_pensions_retraites_rentes égal à
-    somme argent
-      de transforme chaque résultats
+    somme argent de
+    transforme chaque résultats
     parmi résultats_liquidations_plafond_pensions_retraites_rentes en
       résultats.abattement_pensions_retraites_rentes
 
   définition déclarations_avec_plafond_pensions_retraites_rentes_correct égal à
-    si abbattement_total_déplafonné_pensions_retraites_rentes
-      < plafond_abattement_pensions_retraites_rentes alors
+    si
+      abbattement_total_déplafonné_pensions_retraites_rentes
+      < plafond_abattement_pensions_retraites_rentes
+    alors
       # L'abattement total sur le foyer fiscal est en dessous du plafond ;
       # pour chaque déclarant, on met le plafond global (qui ne sera pas
       # atteint de toute façon).
@@ -4301,10 +4316,11 @@ barème de l'impôt sur le revenu.
 
 ```catala
 champ d'application TraitementsSalairesDéclarant:
-  définition minimum_abattement_pensions_retraites_rentes sous condition
-    année_revenus = 2023
-  # Voir commentaire sur le plafond ci-dessus.
-  conséquence égal à 442€
+  définition minimum_abattement_pensions_retraites_rentes
+  sous condition année_revenus = 2023
+    # Voir commentaire sur le plafond ci-dessus.
+  conséquence égal à
+    442€
 
   # Puisqu'on calcule "abattement_pensions_retraites_rentes" à partir de
   # "calcul_abattement_pensions_retraites_rentes", il suit de notre code que
@@ -4383,9 +4399,10 @@ précité ;
 champ d'application TraitementsSalairesDéclarant:
   # Ici, pas d'abattement selon le 5° a)
   exception
-  définition abattement_selon_158_5_a de type_retraite sous condition
-    type_retraite = PensionEnCapitalPlansÉpargneRetraite
-  conséquence égal à faux
+  définition abattement_selon_158_5_a de type_retraite
+  sous condition type_retraite = PensionEnCapitalPlansÉpargneRetraite
+  conséquence égal à
+    faux
 ```
 
 2° Sont imposées selon les modalités prévues aux 1 ou 2 de l'article 200 A pour
@@ -4453,8 +4470,8 @@ champ d'application TraitementsSalairesFoyerFiscal:
   # pour pouvoir mobiliser le même code dans le calcul de la déduction
   # des revenus au quotient de l'article 163-0 A.
   définition
-    calcul_déduction_rente_viagères_titre_onéreux
-    de rente_viagère égal à
+    calcul_déduction_rente_viagères_titre_onéreux de rente_viagère
+  égal à
     rente_viagère.valeur
     * (
       selon rente_viagère.catégorie sous forme
@@ -4467,24 +4484,26 @@ champ d'application TraitementsSalairesFoyerFiscal:
   définition rentes_viagères_titre_onéreux
     état base
   égal à
-    somme argent
-      de transforme chaque rente_viagère
-    parmi [ RenteViagèreOnéreux {
+    somme argent de
+    transforme chaque rente_viagère
+    parmi [
+      RenteViagèreOnéreux {
         -- valeur: revenus.rentes_percues_49moins_ans
         -- catégorie: RenteViagèreOnéreuxMoins49Ans
-      } ;
+      };
       RenteViagèreOnéreux {
         -- valeur: revenus.rentes_percues_50_59ans
         -- catégorie: RenteViagèreOnéreuxEntre50Et59Ans
-      } ;
+      };
       RenteViagèreOnéreux {
         -- valeur: revenus.rentes_percues_60_69ans
         -- catégorie: RenteViagèreOnéreuxEntre60Et69Ans
-      } ;
+      };
       RenteViagèreOnéreux {
         -- valeur: revenus.rentes_percues_70plus_ans
         -- catégorie: RenteViagèreOnéreuxPlus70Ans
-      } ] en
+      }
+    ] en
       rente_viagère.valeur
       - calcul_déduction_rente_viagères_titre_onéreux de rente_viagère
 ```
@@ -4632,53 +4651,53 @@ champ d'application TraitementsSalairesDéclarant:
   # la déduction, et le coefficient de quotientemment calculé à partir
   # de l'échéance du revenu.
   définition revenus_quotientés égal à
-    (
-      transforme chaque revenu parmi revenus.revenus_exceptionnels_ou_différés en
-        (
-          soit déduction égal à
-            selon revenu.catégorie sous forme
-            -- TraitementsSalaires :
-              calcul_déduction_proratisée_revenus_quotientés_traitements_salaires de
-                revenu.valeur
-            -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes :
-              calcul_abattement_proratisé_revenus_quotienté_pensions_retraites de
-                revenu.valeur
-            -- n'importe quel : 0 €
-            # Ce cas ne peut pas arriver, on vérifie qu'on déclare ici uniquement des
-            # revenus qui concernent un déclarant particulier.
-          dans
-          résultat de CalculRevenuQuotienté avec {
-            -- revenu: revenu
-            -- déduction: déduction
-            -- année_revenus: année_revenus
-          }
-        ).revenu_quotienté
-    )
+  (
+    transforme chaque revenu parmi revenus.revenus_exceptionnels_ou_différés en
+      (
+        soit déduction égal à
+          selon revenu.catégorie sous forme
+          -- TraitementsSalaires :
+            calcul_déduction_proratisée_revenus_quotientés_traitements_salaires de
+              revenu.valeur
+          -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes :
+            calcul_abattement_proratisé_revenus_quotienté_pensions_retraites de
+              revenu.valeur
+          -- n'importe quel : 0 €
+          # Ce cas ne peut pas arriver, on vérifie qu'on déclare ici uniquement des
+          # revenus qui concernent un déclarant particulier.
+        dans
+        résultat de CalculRevenuQuotienté avec {
+          -- revenu: revenu
+          -- déduction: déduction
+          -- année_revenus: année_revenus
+        }
+      ).revenu_quotienté
+  )
 
 champ d'application TraitementsSalairesFoyerFiscal:
   définition revenus_quotientés égal à
-    (
-      transforme chaque revenu parmi revenus.revenus_exceptionnels_ou_différés en
-        (
-          soit déduction égal à
-            selon revenu.catégorie sous forme
-            -- RenteViagèreOnéreux contenu catégorie_rente_viagère :
-              calcul_déduction_rente_viagères_titre_onéreux de
-                RenteViagèreOnéreux {
-                  -- valeur: revenu.valeur
-                  -- catégorie: catégorie_rente_viagère
-                }
-            -- n'importe quel : 0 €
-            # Ce cas ne peut pas arriver, on vérifie qu'on déclare ici uniquement des
-            # revenus qui concernent l'ensemble du foyer fiscal.
-          dans
-          résultat de CalculRevenuQuotienté avec {
-            -- revenu: revenu
-            -- déduction: déduction
-            -- année_revenus: année_revenus
-          }
-        ).revenu_quotienté
-    )
+  (
+    transforme chaque revenu parmi revenus.revenus_exceptionnels_ou_différés en
+      (
+        soit déduction égal à
+          selon revenu.catégorie sous forme
+          -- RenteViagèreOnéreux contenu catégorie_rente_viagère :
+            calcul_déduction_rente_viagères_titre_onéreux de
+              RenteViagèreOnéreux {
+                -- valeur: revenu.valeur
+                -- catégorie: catégorie_rente_viagère
+              }
+          -- n'importe quel : 0 €
+          # Ce cas ne peut pas arriver, on vérifie qu'on déclare ici uniquement des
+          # revenus qui concernent l'ensemble du foyer fiscal.
+        dans
+        résultat de CalculRevenuQuotienté avec {
+          -- revenu: revenu
+          -- déduction: déduction
+          -- année_revenus: année_revenus
+        }
+      ).revenu_quotienté
+  )
 
 champ d'application BénéficesNonCommerciauxDéclarant:
   # Ici, nous effectuons le pro-rata à la main et calculons le solde restant
@@ -4930,8 +4949,8 @@ dix années.
 # le quotient des revenus différés, où il n'y a pas de décalage de 1 an.
 champ d'application CalculRevenuQuotienté:
   exception
-  définition décalage_échéance_prise_en_compte sous condition
-    revenu.régime sous forme Article163_0_A_bis
+  définition décalage_échéance_prise_en_compte
+  sous condition revenu.régime sous forme Article163_0_A_bis
   conséquence égal à
     0
 ```
@@ -4963,9 +4982,10 @@ champ d'application TraitementsSalairesDéclarant:
 
   # Ici donc pas d'abattement selon l'article 158 5° a)
   exception
-  définition abattement_selon_158_5_a de type_retraite sous condition
-    type_retraite = PensionEnCapital_7_5pct
-  conséquence égal à faux
+  définition abattement_selon_158_5_a de type_retraite
+  sous condition type_retraite = PensionEnCapital_7_5pct
+  conséquence égal à
+    faux
 
 # TODO informatique: ajouter d'éventuels autres prélèvements libératoires à la
 # variable à travers des états
@@ -5147,7 +5167,8 @@ et ainsi de suite, en augmentant d'une part par enfant à charge du
 contribuable.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2017:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2017:
   # TODO juridique: ici nous supposons qu'il faut restreindre le comptage
   # des enfants pris en compte à ceux qui sont mineurs et non mariés ou
   # invalides : Si on ne fait pas cette restriction on risque de prendre
@@ -5230,7 +5251,8 @@ c) 0,5 part pour chacun des enfants, lorsque par ailleurs le contribuable
 assume la charge exclusive ou principale d'au moins deux enfants.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2017:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2017:
   # TODO juridique: ici nous supposons qu'il faut restreindre le comptage
   # des enfants pris en compte à ceux qui sont mineurs et non mariés ou
   # invalides : Si on ne fait pas cette restriction on risque de prendre
@@ -5300,7 +5322,8 @@ minutes d'un notaire ou d'une décision de justice pour l'entretien desdits
 enfants.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2017:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2017:
   définition nombre_de_parts
     état parent_isolé_194
   égal à
@@ -5343,11 +5366,12 @@ charge, exclusive, principale ou réputée également partagée entre les
 parents, est divisé par 1,5 lorsque ces contribuables :
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   exception
   définition nombre_de_parts
     état parent_isolé_194
-  # Dernier état du calcul après application de l'article 194
+    # Dernier état du calcul après application de l'article 194
   sous condition
     (
       selon situation_familiale sous forme
@@ -5377,10 +5401,11 @@ au moins de ces enfants pendant au moins cinq années au cours desquelles ils
 vivaient seuls ;
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   étiquette paragraphe_1_195
-  règle situation_195_1_applicable sous condition
-    foyer_fiscal.célibataire_divorcé_veuf_sans_enfant
+  règle situation_195_1_applicable
+  sous condition foyer_fiscal.célibataire_divorcé_veuf_sans_enfant
   # Case AL qui vaut pour a. et b.
   conséquence rempli
 ```
@@ -5391,10 +5416,11 @@ militaires d'invalidité et des victimes de guerre reproduisant celles des lois
 des 31 mars et 24 juin 1919 ;
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   étiquette paragraphe_1_195
-  règle situation_195_1_applicable sous condition
-    foyer_fiscal.pensionné_veuve_de_guerre
+  règle situation_195_1_applicable
+  sous condition foyer_fiscal.pensionné_veuve_de_guerre
   conséquence rempli
 ```
 
@@ -5406,10 +5432,11 @@ invalidité ” prévue à l'article L. 241-3 du code de l'action sociale et des
 familles ;
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   étiquette paragraphe_1_195
-  règle situation_195_1_applicable sous condition
-    foyer_fiscal.titulaire_carte_invalidité_CMI_invalidité_40_pourcent
+  règle situation_195_1_applicable
+  sous condition foyer_fiscal.titulaire_carte_invalidité_CMI_invalidité_40_pourcent
   conséquence rempli
 ```
 
@@ -5434,10 +5461,11 @@ mentionnées ci-dessus ainsi que des personnes titulaires de la carte du
 combattant au moment de leur décès.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   étiquette paragraphe_1_195
-  règle situation_195_1_applicable sous condition
-    foyer_fiscal.pensionné_guerre_célibataire_veuf
+  règle situation_195_1_applicable
+  sous condition foyer_fiscal.pensionné_guerre_célibataire_veuf
   conséquence rempli
 ```
 
@@ -5448,7 +5476,8 @@ mobilité inclusion ” portant la mention “ invalidité ” prévue à l'arti
 L. 241-3 du code de l'action sociale et des familles.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   # Ici on pourrait se demander si la bonification n'intervient pas à cause de
   # la carte invalidité des parents mais le BOI-IR-LIQ-10-20-20-20 paragraphe 1
   # dit clairement que ce n'est pas le cas.
@@ -5458,8 +5487,8 @@ champ d'application NombreDeParts sous condition année_revenus >= 2021:
     nombre_de_parts
     + décimal de nombre_enfants_à_charge_mineurs_et_non_mariés_invalides * 0,5
     + décimal de
-      foyer_fiscal.nombre_enfants_à_charge_résidence_alternée_invalides
-    * 0,25
+        foyer_fiscal.nombre_enfants_à_charge_résidence_alternée_invalides
+      * 0,25
 # Ici normalement chaque enfant en résidence alternée invalide est compté
 # deux fois (cases CH et CI) donc 2*0,25=0,5.
 ```
@@ -5469,13 +5498,15 @@ pour les contribuables mariés, lorsque l'un ou l'autre des conjoints
 remplit l'une des conditions fixées aux c, d et d bis du 1.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   définition nombre_de_parts
     état paragraphe_3_195
   égal à
     nombre_de_parts
     + (
-      si (
+      si
+        (
           selon situation_familiale sous forme
           -- Mariées : vrai
           -- Pacsées : vrai
@@ -5484,8 +5515,9 @@ champ d'application NombreDeParts sous condition année_revenus >= 2021:
         et (
           foyer_fiscal.titulaire_carte_invalidité_CMI_invalidité_40_pourcent
           ou foyer_fiscal.
-            conjoint_titulaire_carte_invalidité_CMI_invalidité_40_pourcent
-        ) alors
+              conjoint_titulaire_carte_invalidité_CMI_invalidité_40_pourcent
+        )
+      alors
         0,5
       sinon 0,0
     )
@@ -5496,13 +5528,15 @@ contribuables mariés invalides lorsque chacun des conjoints remplit l'une
 des conditions fixées aux c, d et d bis du 1.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   définition nombre_de_parts
     état paragraphe_4_195
   égal à
     nombre_de_parts
     + (
-      si (
+      si
+        (
           selon situation_familiale sous forme
           -- Mariées : vrai
           -- Pacsées : vrai
@@ -5511,8 +5545,9 @@ champ d'application NombreDeParts sous condition année_revenus >= 2021:
         et (
           foyer_fiscal.titulaire_carte_invalidité_CMI_invalidité_40_pourcent
           et foyer_fiscal.
-            conjoint_titulaire_carte_invalidité_CMI_invalidité_40_pourcent
-        ) alors
+              conjoint_titulaire_carte_invalidité_CMI_invalidité_40_pourcent
+        )
+      alors
         0,5
       sinon 0,0
     )
@@ -5525,13 +5560,15 @@ partagée entre les parents, lorsque ces contribuables remplissent l'une des
 conditions d'invalidité fixées aux c, d ou d bis du 1.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   définition nombre_de_parts
     état paragraphe_5_195
   égal à
     nombre_de_parts
     + (
-      si (
+      si
+        (
           selon situation_familiale sous forme
           -- Célibataire : vrai
           -- DivorcéeSéparées : vrai
@@ -5546,7 +5583,8 @@ champ d'application NombreDeParts sous condition année_revenus >= 2021:
         et (
           foyer_fiscal.pensionné_veuve_de_guerre
           ou foyer_fiscal.titulaire_carte_invalidité_CMI_invalidité_40_pourcent
-        ) alors
+        )
+      alors
         0,5
       sinon 0,0
     )
@@ -5559,7 +5597,8 @@ victimes de guerre, bénéficient d'une demi-part supplémentaire de quotient
 familial.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   définition nombre_de_parts
     état paragraphe_6_195
   égal à
@@ -5578,9 +5617,11 @@ Les contribuables qui bénéficient des dispositions des 3 ou 4 ne peuvent
 bénéficier des dispositions du premier alinéa.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus >= 2021:
+champ d'application NombreDeParts
+sous condition année_revenus >= 2021:
   exception paragraphe_1_195
-  règle situation_195_1_applicable sous condition
+  règle situation_195_1_applicable
+  sous condition
     (
       selon situation_familiale sous forme
       -- Mariées : vrai
@@ -5649,13 +5690,14 @@ l'article 6 bénéficie d'une demi-part supplémentaire de quotient familial par
 personne ainsi rattachée.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus = 2023:
+champ d'application NombreDeParts
+sous condition année_revenus = 2023:
   définition nombre_de_parts
     état article_196_B
   égal à
     nombre_de_parts
     + décimal de foyer_fiscal.nombre_enfants_majeurs_célibataires_sans_enfant
-    * 0,5
+      * 0,5
 ```
 
 Si la personne rattachée est mariée ou a des enfants à charge, l'avantage
@@ -5666,7 +5708,8 @@ l'autre de leurs parents, l'abattement auquel ils ouvrent droit pour le
 contribuable, est égal à la moitié de cette somme.
 
 ```catala
-champ d'application NombreDeParts sous condition année_revenus = 2023:
+champ d'application NombreDeParts
+sous condition année_revenus = 2023:
   # Attention, l'année des revenus sur lesquels porte ce montant d'abattement
   # est généralement l'année N-1 si la version de cet article entre en vigueur
   # l'année N. En effet, l'abattement sur la déclaration de l'année N-1 est
@@ -5928,10 +5971,12 @@ champ d'application TraitementsSalairesDéclarant:
     état art204c
   égal à
     pensions_retraites_rentes_79
-    ++ [ PensionRetraiteRente {
+    ++ [
+      PensionRetraiteRente {
         -- valeur_initiale: revenus.autre_pensions_imposables_source_étrangère
         -- type_pension: TypePensionRetraiteRente.PensionsRetraitesRentes
-      } ]
+      }
+    ]
 ```
 
 NOTA :

--- a/tests/fr/cgi_revenus.catala_fr.result
+++ b/tests/fr/cgi_revenus.catala_fr.result
@@ -117,9 +117,9 @@ champ d'application TraitementsSalairesFoyerFiscal:
   égal à
     (
       somme argent de
-      transforme chaque résultats
-      parmi déclarations_avec_résultats_traitements_salaires en
-        résultats.revenu_brut_déclarant_hors_quotient
+        transforme chaque résultats
+        parmi déclarations_avec_résultats_traitements_salaires en
+          résultats.revenu_brut_déclarant_hors_quotient
     )
     + rentes_viagères_titre_onéreux
     # Gain d'acquisition d'action gratuites postérieures à 2016 pour
@@ -182,15 +182,15 @@ champ d'application BénéficesNonCommerciauxFoyerFiscal:
     état agrégation
   égal à
     somme argent de
-    transforme chaque résultat_liquidation
-    parmi résultats_liquidation_bénéfices_non_commerciaux en
-      résultat_liquidation.solde_net_non_professionnel
+      transforme chaque résultat_liquidation
+      parmi résultats_liquidation_bénéfices_non_commerciaux en
+        résultat_liquidation.solde_net_non_professionnel
 
   définition solde_net_global_professionnel égal à
     somme argent de
-    transforme chaque résultat_liquidation
-    parmi résultats_liquidation_bénéfices_non_commerciaux en
-      résultat_liquidation.solde_net_professionnel
+      transforme chaque résultat_liquidation
+      parmi résultats_liquidation_bénéfices_non_commerciaux en
+        résultat_liquidation.solde_net_professionnel
 
   définition revenu_brut_global égal à
     # Le 2° du I de l'article 156 précise que les déficits non-professionnels
@@ -215,23 +215,23 @@ champ d'application BénéficesIndustrielsCommerciauxFoyerFiscal:
     état agrégation
   égal à
     somme argent de
-    transforme chaque résultat_liquidation
-    parmi résultats_liquidation_bénéfices_industriels_commerciaux en
-      résultat_liquidation.solde_net_non_professionnel_hors_locations_meublées
+      transforme chaque résultat_liquidation
+      parmi résultats_liquidation_bénéfices_industriels_commerciaux en
+        résultat_liquidation.solde_net_non_professionnel_hors_locations_meublées
 
   définition solde_net_global_professionnel égal à
     somme argent de
-    transforme chaque résultat_liquidation
-    parmi résultats_liquidation_bénéfices_industriels_commerciaux en
-      résultat_liquidation.solde_net_professionnel
+      transforme chaque résultat_liquidation
+      parmi résultats_liquidation_bénéfices_industriels_commerciaux en
+        résultat_liquidation.solde_net_professionnel
 
   définition solde_net_global_non_professionnel_locations_meublées
     état agrégation
   égal à
     somme argent de
-    transforme chaque résultat_liquidation
-    parmi résultats_liquidation_bénéfices_industriels_commerciaux en
-      résultat_liquidation.solde_net_non_professionnel_locations_meublées
+      transforme chaque résultat_liquidation
+      parmi résultats_liquidation_bénéfices_industriels_commerciaux en
+        résultat_liquidation.solde_net_non_professionnel_locations_meublées
 
   définition revenu_brut_global égal à
     # Le 1°bis du I de l'article 156 précise que les déficits non-professionnels
@@ -884,8 +884,21 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
           abattement_spécial_micro_total_location_meublées_rurales_spéciales
             état arrondissement
         ),
-        Absent, Absent, Absent, Absent, Absent, Absent,
-        [], [], [], [], [], [], [], [], []
+        Absent,
+        Absent,
+        Absent,
+        Absent,
+        Absent,
+        Absent,
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        []
       )
 
   définition abattement_forfaitaire_micro_total_marchandises
@@ -948,21 +961,21 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
     revenus.professionnels.revenus_imposables_micro_marchandises
     + (
       somme argent de
-      transforme chaque revenu_exceptionnel_ou_différé
-      parmi revenus_exceptionnels_professionnels_abattement_micro_marchandises en
-        revenu_exceptionnel_ou_différé.valeur
+        transforme chaque revenu_exceptionnel_ou_différé
+        parmi revenus_exceptionnels_professionnels_abattement_micro_marchandises en
+          revenu_exceptionnel_ou_différé.valeur
     )
     + revenus.non_professionnels.généraux.revenus_imposables_micro_marchandises
     + (
       somme argent de
-      transforme chaque revenu_exceptionnel_ou_différé
-      parmi revenus_exceptionnels_non_professionnels_abattement_micro_marchandises en
-        revenu_exceptionnel_ou_différé.valeur
+        transforme chaque revenu_exceptionnel_ou_différé
+        parmi revenus_exceptionnels_non_professionnels_abattement_micro_marchandises en
+          revenu_exceptionnel_ou_différé.valeur
     )
     + (
       somme argent de transforme chaque revenu_exceptionnel_ou_différé
-      parmi revenus_exceptionnels_non_professionnels_locations_meublées_rurales_spéciales en
-        revenu_exceptionnel_ou_différé.valeur
+        parmi revenus_exceptionnels_non_professionnels_locations_meublées_rurales_spéciales en
+          revenu_exceptionnel_ou_différé.valeur
     )
     + revenus.non_professionnels.locations_meublées_micro_hôtes_classées
     + revenus.non_professionnels.locations_meublées_micro_classées_rurales_spéciales
@@ -1049,15 +1062,15 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
     revenus.professionnels.revenus_imposables_micro_services
     + (
       somme argent de
-      transforme chaque revenu_exceptionnel_ou_différé
-      parmi revenus_exceptionnels_professionnels_abattement_micro_services en
-        revenu_exceptionnel_ou_différé.valeur
+        transforme chaque revenu_exceptionnel_ou_différé
+        parmi revenus_exceptionnels_professionnels_abattement_micro_services en
+          revenu_exceptionnel_ou_différé.valeur
     )
     + revenus.non_professionnels.généraux.revenus_imposables_micro_services
     + (
       somme argent de transforme chaque revenu_exceptionnel_ou_différé
-      parmi revenus_exceptionnels_non_professionnels_abattement_micro_services en
-        revenu_exceptionnel_ou_différé.valeur
+        parmi revenus_exceptionnels_non_professionnels_abattement_micro_services en
+          revenu_exceptionnel_ou_différé.valeur
     )
     + revenus.non_professionnels.locations_meublées_micro_général
     + revenus.non_professionnels.locations_meublées_micro_cotisations_général
@@ -1130,8 +1143,8 @@ champ d'application BénéficesIndustrielsCommerciauxDéclarant:
     revenus.non_professionnels.locations_meublées_micro_classées_rurales_spéciales
     + revenus.non_professionnels.locations_meublées_micro_cotisations_classées_rurales_spéciales
     + somme argent de transforme chaque revenu_exceptionnel_ou_différé
-      parmi revenus_exceptionnels_non_professionnels_locations_meublées_rurales_spéciales en
-        revenu_exceptionnel_ou_différé.valeur
+        parmi revenus_exceptionnels_non_professionnels_locations_meublées_rurales_spéciales en
+          revenu_exceptionnel_ou_différé.valeur
 
   # L'assiette de cet abattement ne comprend pas les revenus de locations
   # meublées professionnelles qui pourrait également rentrer dans le régime
@@ -2352,13 +2365,13 @@ champ d'application TraitementsSalairesDéclarant:
   égal à
     (
       somme argent de
-      transforme chaque r_quotienté parmi revenus.revenus_exceptionnels_ou_différés en
-        (
-          selon r_quotienté.catégorie sous forme
-          -- TraitementsSalaires :
-            calcul_déduction_frais_professionnels de r_quotienté.valeur
-          -- n'importe quel : 0 €
-        )
+        transforme chaque r_quotienté parmi revenus.revenus_exceptionnels_ou_différés en
+          (
+            selon r_quotienté.catégorie sous forme
+            -- TraitementsSalaires :
+              calcul_déduction_frais_professionnels de r_quotienté.valeur
+            -- n'importe quel : 0 €
+          )
     )
     + déduction_frais_professionnels_traitements_salaires_avant_prorata
 
@@ -2389,11 +2402,11 @@ champ d'application TraitementsSalairesDéclarant:
     # de calcul où l'on applique les frais réels.
     déduction_frais_professionnels_totale
     - somme argent de transforme chaque r_quotienté parmi revenus_quotientés en
-        (
-          selon r_quotienté.catégorie sous forme
-          -- TraitementsSalaires : r_quotienté.déduction
-          -- n'importe quel : 0€
-        )
+          (
+            selon r_quotienté.catégorie sous forme
+            -- TraitementsSalaires : r_quotienté.déduction
+            -- n'importe quel : 0€
+          )
 ```
 
 Le montant de la déduction forfaitaire pour frais professionnels ne peut être inférieur à 495 €,
@@ -2573,14 +2586,14 @@ champ d'application TraitementsSalairesDéclarant:
         / (
           traitements_salaires_avec_déduction_frais_professionnels
           + somme argent de
-            transforme chaque autre_revenu_quotienté
-            parmi revenus.revenus_exceptionnels_ou_différés en
-              (
-                selon autre_revenu_quotienté.catégorie sous forme
-                -- CatégorieRevenuExceptionnelOuDifféré.TraitementsSalaires :
-                  autre_revenu_quotienté.valeur
-                -- n'importe quel : 0 €
-              )
+              transforme chaque autre_revenu_quotienté
+              parmi revenus.revenus_exceptionnels_ou_différés en
+                (
+                  selon autre_revenu_quotienté.catégorie sous forme
+                  -- CatégorieRevenuExceptionnelOuDifféré.TraitementsSalaires :
+                    autre_revenu_quotienté.valeur
+                  -- n'importe quel : 0 €
+                )
         )
       )
       dans
@@ -2991,8 +3004,8 @@ champ d'application BénéficesNonCommerciauxDéclarant:
     + (somme argent de transforme chaque revenu parmi revenus_exceptionnels_professionnels_abattement_micro en revenu.valeur)
     + revenus.non_professionnels.généraux.revenus_imposables_micro
     + somme argent de transforme chaque revenu
-      parmi revenus_exceptionnels_non_professionnels_abattement_micro en
-        revenu.valeur
+        parmi revenus_exceptionnels_non_professionnels_abattement_micro en
+          revenu.valeur
 
   définition abattement_forfaitaire_micro_total
     état base
@@ -3393,13 +3406,13 @@ champ d'application ImputationDéficitSurRevenusQuotientés:
   # négatifs ? [Denis : normalement pas de revenu négatif...]
   définition base_d_imputation_déficit_catégoriel égal à
     somme argent de
-    transforme chaque revenus_quotientés_catégoriels_déclarant
-    parmi revenus_quotientés_catégoriels en
-      (
-        somme argent de transforme chaque revenu_quotienté_catégoriel
-        parmi revenus_quotientés_catégoriels_déclarant en
-          revenu_quotienté_catégoriel.valeur_nette
-      )
+      transforme chaque revenus_quotientés_catégoriels_déclarant
+      parmi revenus_quotientés_catégoriels en
+        (
+          somme argent de transforme chaque revenu_quotienté_catégoriel
+            parmi revenus_quotientés_catégoriels_déclarant en
+              revenu_quotienté_catégoriel.valeur_nette
+        )
 
   # Ensuite, nous déterminons le déficit à imputer : il s'agit du solde du
   # revenu brut global du foyer fiscal, hors revenus au quotient (puisque c'est
@@ -4217,13 +4230,13 @@ champ d'application TraitementsSalairesDéclarant:
     abattement_pensions_retraites_rentes_total_plafonné
     - (
       somme argent de
-      transforme chaque r_quotienté parmi revenus_quotientés en
-        (
-          selon r_quotienté.catégorie sous forme
-          -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes :
-            r_quotienté.déduction
-          -- n'importe quel : 0€
-        )
+        transforme chaque r_quotienté parmi revenus_quotientés en
+          (
+            selon r_quotienté.catégorie sous forme
+            -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes :
+              r_quotienté.déduction
+            -- n'importe quel : 0€
+          )
     )
 
 # Ensuite, il nous faut coder la logique qui lance la double liquidation
@@ -4248,9 +4261,9 @@ champ d'application TraitementsSalairesFoyerFiscal:
   # sur tout le foyer fiscal.
   définition abbattement_total_déplafonné_pensions_retraites_rentes égal à
     somme argent de
-    transforme chaque résultats
-    parmi résultats_liquidations_plafond_pensions_retraites_rentes en
-      résultats.abattement_pensions_retraites_rentes
+      transforme chaque résultats
+      parmi résultats_liquidations_plafond_pensions_retraites_rentes en
+        résultats.abattement_pensions_retraites_rentes
 
   définition déclarations_avec_plafond_pensions_retraites_rentes_correct égal à
     si
@@ -4485,27 +4498,27 @@ champ d'application TraitementsSalairesFoyerFiscal:
     état base
   égal à
     somme argent de
-    transforme chaque rente_viagère
-    parmi [
-      RenteViagèreOnéreux {
-        -- valeur: revenus.rentes_percues_49moins_ans
-        -- catégorie: RenteViagèreOnéreuxMoins49Ans
-      };
-      RenteViagèreOnéreux {
-        -- valeur: revenus.rentes_percues_50_59ans
-        -- catégorie: RenteViagèreOnéreuxEntre50Et59Ans
-      };
-      RenteViagèreOnéreux {
-        -- valeur: revenus.rentes_percues_60_69ans
-        -- catégorie: RenteViagèreOnéreuxEntre60Et69Ans
-      };
-      RenteViagèreOnéreux {
-        -- valeur: revenus.rentes_percues_70plus_ans
-        -- catégorie: RenteViagèreOnéreuxPlus70Ans
-      }
-    ] en
-      rente_viagère.valeur
-      - calcul_déduction_rente_viagères_titre_onéreux de rente_viagère
+      transforme chaque rente_viagère
+      parmi [
+        RenteViagèreOnéreux {
+          -- valeur: revenus.rentes_percues_49moins_ans
+          -- catégorie: RenteViagèreOnéreuxMoins49Ans
+        };
+        RenteViagèreOnéreux {
+          -- valeur: revenus.rentes_percues_50_59ans
+          -- catégorie: RenteViagèreOnéreuxEntre50Et59Ans
+        };
+        RenteViagèreOnéreux {
+          -- valeur: revenus.rentes_percues_60_69ans
+          -- catégorie: RenteViagèreOnéreuxEntre60Et69Ans
+        };
+        RenteViagèreOnéreux {
+          -- valeur: revenus.rentes_percues_70plus_ans
+          -- catégorie: RenteViagèreOnéreuxPlus70Ans
+        }
+      ] en
+        rente_viagère.valeur
+        - calcul_déduction_rente_viagères_titre_onéreux de rente_viagère
 ```
 
 6 bis. Lorsqu'ils sont pris en compte dans l'assiette du revenu net global dans

--- a/tests/fr/code_construction_legislatif.catala_fr.result
+++ b/tests/fr/code_construction_legislatif.catala_fr.result
@@ -41,8 +41,8 @@ la résidence principale.
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  règle condition_logement_résidence_principale sous condition
-    ménage.logement.résidence_principale
+  règle condition_logement_résidence_principale
+  sous condition ménage.logement.résidence_principale
   conséquence rempli
 ```
 
@@ -75,7 +75,8 @@ payeur.
 # la méta-structure logique des articles de loi de ce chapitre.
 champ d'application ÉligibilitéAidesPersonnelleLogement:
 
-  règle éligibilité_logement sous condition
+  règle éligibilité_logement
+  sous condition
     # La condition logement est en fait l'amalgame de plusieurs sous-conditions
     # portant toutes sur le logement définies au long des diverses parties
     # du code de la construction et de l'habitation. Attention, ne pas oublier
@@ -88,7 +89,8 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
   conséquence rempli
 
   exception
-  règle éligibilité_logement sous condition
+  règle éligibilité_logement
+  sous condition
     condition_non_ouverture_l822_8
     ou condition_non_ouverture_l822_9_decence_logement
   conséquence non rempli
@@ -144,7 +146,8 @@ Les sous-locataires, sous les mêmes conditions, peuvent également en bénéfic
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   étiquette l822_2
-  règle condition_logement_mode_occupation sous condition
+  règle condition_logement_mode_occupation
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- Locataire : vrai
     -- RésidentLogementFoyer : vrai
@@ -180,7 +183,8 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     )
 
   étiquette l822_3_1 exception l822_2
-  règle condition_logement_mode_occupation sous condition
+  règle condition_logement_mode_occupation
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- Locataire : usufruit_ou_propriété_famille
     -- n'importe quel : faux
@@ -195,7 +199,8 @@ Ces seuils ne peuvent excéder 20 % de la propriété ou de l'usufruit du logeme
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   étiquette l822_3_2 exception l822_3_1
-  règle condition_logement_mode_occupation sous condition
+  règle condition_logement_mode_occupation
+  sous condition
     usufruit_ou_propriété_famille
     et (
       selon ménage.logement.propriétaire sous forme
@@ -204,11 +209,11 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     )
     < seuil_l822_3_parts_propriété
     et (
-      selon ménage.logement.usufruit sous forme
-      -- DemandeurOuConjointOuParentOuViaPartsSociétés contenu parts : parts
-      -- ParentOuAutre.Autre : 0,0
-    )
-    < seuil_l822_3_parts_usufruit
+        selon ménage.logement.usufruit sous forme
+        -- DemandeurOuConjointOuParentOuViaPartsSociétés contenu parts : parts
+        -- ParentOuAutre.Autre : 0,0
+      )
+      < seuil_l822_3_parts_usufruit
   conséquence rempli
   # Les < sont stricts par mention de R822-1
 
@@ -227,12 +232,13 @@ personne de moins de trente ans.
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   étiquette cas_base_l822_4
-  règle condition_logement_location_tiers sous condition
-    ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme LouéOuSousLouéÀDesTiers.Non
+  règle condition_logement_location_tiers
+  sous condition ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme LouéOuSousLouéÀDesTiers.Non
   conséquence non rempli
 
   exception cas_base_l822_4
-  règle condition_logement_location_tiers sous condition
+  règle condition_logement_location_tiers
+  sous condition
     selon ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme
     -- LouéOuSousLouéÀDesTiers.Non : vrai
     -- LouéOuSousLouéÀDesTiers.Oui contenu personne :
@@ -360,8 +366,8 @@ logement. Cette condition est appréciée pour chacun des membres du ménage.
 # L'interpretation est donc qu'aucun membre du ménage ne doit être
 # rattaché à des parents payant l'ifi.
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  règle condition_non_ouverture_l822_8 sous condition
-    ménage.condition_rattaché_foyer_fiscal_parent_ifi
+  règle condition_non_ouverture_l822_8
+  sous condition ménage.condition_rattaché_foyer_fiscal_parent_ifi
   conséquence rempli
 ```
 
@@ -374,8 +380,8 @@ locatifs et portant modification de la loi n° 86-1290 du 23 décembre 1986.
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  règle condition_non_ouverture_l822_9_decence_logement sous condition
-    non ménage.logement.logement_decent_l89_462
+  règle condition_non_ouverture_l822_9_decence_logement
+  sous condition non ménage.logement.logement_decent_l89_462
   conséquence rempli
 ```
 
@@ -399,8 +405,8 @@ respect de conditions de peuplement des logements.
 # Cet article fait référence à la condition sur la surface minimale du logement
 # de R822-25
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  règle condition_ouverture_l822_10_peuplement_logement sous condition
-    condition_logement_surface
+  règle condition_ouverture_l822_10_peuplement_logement
+  sous condition condition_logement_surface
   conséquence rempli
 ```
 
@@ -447,17 +453,18 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
   règle septième_alinéa_l823_1_applicable rempli
 
   exception r823_4_enfants
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     septième_alinéa_l823_1_applicable
     et selon personne_à_charge sous forme
-    -- EnfantÀCharge contenu enfant :
-      (
-        selon enfant.nationalité sous forme
-        -- Étrangère contenu conditions :
-          non conditions.satisfait_conditions_l512_2_code_sécurité_sociale
-        -- n'importe quel : faux
-      )
-    -- n'importe quel : faux
+      -- EnfantÀCharge contenu enfant :
+        (
+          selon enfant.nationalité sous forme
+          -- Étrangère contenu conditions :
+            non conditions.satisfait_conditions_l512_2_code_sécurité_sociale
+          -- n'importe quel : faux
+        )
+      -- n'importe quel : faux
   conséquence non rempli
 ```
 
@@ -596,12 +603,13 @@ de l'aide.
 ```catala
 # Voir le champ d'application ÉligibilitéPrimeDeDéménagement.
 champ d'application ÉligibilitéPrimeDeDéménagement:
-  règle éligibilité sous condition
+  règle éligibilité
+  sous condition
     éligibilité_apl.éligibilité
     et condition_rang_enfant
     et condition_période_déménagement
     et éligibilité_apl.date_courante - date_emménagement
-    <= délai_après_emménagement_l823_8_2
+      <= délai_après_emménagement_l823_8_2
   conséquence rempli
 ```
 
@@ -621,7 +629,8 @@ indûment versés.
 
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
-  règle éligibilité sous condition
+  règle éligibilité
+  sous condition
     # La condition est en fait l'amalgame de plusieurs sous-conditions
     # portant toutes sur le logement définies au long des diverses parties
     # du code de la construction et de l'habitation. Attention, ne pas oublier
@@ -630,7 +639,7 @@ champ d'application ÉligibilitéAidePersonnaliséeLogement:
     et # L831-1
     condition_logement_prêt
     et # L831-2
-    éligibilité_commune.éligibilité
+      éligibilité_commune.éligibilité
   # Pour être éligible à l'aide personnalisée
   # au logement, il faut remplir les
   # conditions communes.
@@ -657,7 +666,8 @@ conditions d'octroi sont fixées par voie réglementaire, sous les réserves
 # exception à la règle de L822-2 quand les conditions relatives au prêt ne
 # sont pas remplies.
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- AccessionPropriétéLocalUsageExclusifHabitation contenu propriété :
       caractéristiques_prêt_l831_1_1 de propriété.prêt
@@ -678,7 +688,8 @@ régies par la section 3 du chapitre Ier du titre II du livre III ;
 
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- Locataire contenu location :
       (
@@ -724,7 +735,8 @@ des conventions régies par le chapitre III du titre V du livre III ;
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
   étiquette logement_foyer
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- RésidentLogementFoyer contenu location :
       location.conventionné_livre_III_titre_V_chap_III
@@ -741,7 +753,8 @@ fixées par voie réglementaire, sous les réserves énoncées à l ‘ article 
 
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- LocationAccession contenu propriété :
       caractéristiques_prêt_l831_1_6 de propriété.prêt
@@ -761,7 +774,8 @@ champ d'application ÉligibilitéAidePersonnaliséeLogement:
   # Cas de base implicite
 
   étiquette l831_2_1 exception l831_2_base
-  règle condition_logement_prêt sous condition
+  règle condition_logement_prêt
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- LocationAccession contenu propriété :
       propriété.prêt.date_signature >= |2017-12-31|
@@ -781,7 +795,8 @@ d'accès au logement dans le parc résidentiel existant.
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
   exception l831_2_1
-  règle condition_logement_prêt sous condition
+  règle condition_logement_prêt
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- LocationAccession contenu propriété :
       # Le fait que cette exception ne soit valable qu'après le 1er janvier
@@ -883,8 +898,10 @@ champ d'application ÉligibilitéAllocationLogement:
   définition éligibilité
     état dispositions_communes
   égal à
-    si (non éligibilité_commune.éligibilité)
-      ou (non condition_accession_propriété) alors
+    si
+      (non éligibilité_commune.éligibilité)
+      ou (non condition_accession_propriété)
+    alors
       PasÉligible
     sinon
       # Valeur par défaut, sera réécrit à l'application de L841-2.
@@ -910,15 +927,16 @@ d) Soit l'allocation de soutien familial mentionnée au 6° du même article ;
 champ d'application ÉligibilitéAllocationLogement:
   règle l_841_1_1_applicable rempli
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     l_841_1_1_applicable
     et existe prestation parmi ménage.prestations_reçues
-      tel que (
-        prestation = PrestationReçue.AllocationsFamiliales
-        ou prestation = PrestationReçue.ComplémentFamilial
-        ou prestation = PrestationReçue.AllocationSoutienFamilial
-        ou prestation = AllocationSoutienEnfantHandicapé
-      )
+        tel que (
+          prestation = PrestationReçue.AllocationsFamiliales
+          ou prestation = PrestationReçue.ComplémentFamilial
+          ou prestation = PrestationReçue.AllocationSoutienFamilial
+          ou prestation = AllocationSoutienEnfantHandicapé
+        )
   conséquence rempli
 ```
 
@@ -932,27 +950,28 @@ ont un enfant à charge au sens de l'article L. 512-3 du code de la sécurité s
 champ d'application ÉligibilitéAllocationLogement:
   règle l_841_1_2_applicable rempli
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     l_841_1_2_applicable
     et nombre de
-      (
-        liste de personne_à_charge parmi ménage.personnes_à_charge
-          tel que (
-            selon personne_à_charge sous forme
-            -- AutrePersonneÀCharge : faux
-            -- EnfantÀCharge contenu enfant :
-              prestations_familiales.droit_ouvert de
-                Prestations_familiales.EnfantPrestationsFamiliales {
-                  -- identifiant: enfant.identifiant
-                  -- obligation_scolaire: enfant.obligation_scolaire
-                  -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
-                  -- date_de_naissance: enfant.date_de_naissance
-                  -- a_déjà_ouvert_droit_aux_allocations_familiales:
-                    enfant.a_déjà_ouvert_droit_aux_allocations_familiales
-                }
-          )
-      )
-    = 1
+        (
+          liste de personne_à_charge parmi ménage.personnes_à_charge
+            tel que (
+              selon personne_à_charge sous forme
+              -- AutrePersonneÀCharge : faux
+              -- EnfantÀCharge contenu enfant :
+                prestations_familiales.droit_ouvert de
+                  Prestations_familiales.EnfantPrestationsFamiliales {
+                    -- identifiant: enfant.identifiant
+                    -- obligation_scolaire: enfant.obligation_scolaire
+                    -- rémuneration_mensuelle: enfant.rémuneration_mensuelle
+                    -- date_de_naissance: enfant.date_de_naissance
+                    -- a_déjà_ouvert_droit_aux_allocations_familiales:
+                      enfant.a_déjà_ouvert_droit_aux_allocations_familiales
+                  }
+            )
+        )
+      = 1
   conséquence rempli
 ```
 
@@ -961,7 +980,8 @@ champ d'application ÉligibilitéAllocationLogement:
 ```catala
 champ d'application ÉligibilitéAllocationLogement:
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     nombre de
       (
         liste de personne_à_charge parmi ménage.personnes_à_charge
@@ -1000,7 +1020,8 @@ un âge déterminé ;
 # renvoie au 2° du R823-4 du même code.
 champ d'application ÉligibilitéAllocationLogement:
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     existe personne_à_charge parmi ménage.personnes_à_charge
       tel que éligibilité_commune.condition_2_r823_4 de personne_à_charge
   conséquence rempli
@@ -1016,7 +1037,8 @@ prévue par l'article L. 146-9 du code de l'action sociale et des familles ;
 ```catala
 champ d'application ÉligibilitéAllocationLogement:
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     existe personne_à_charge parmi ménage.personnes_à_charge
       tel que (
         selon personne_à_charge sous forme
@@ -1040,13 +1062,14 @@ quatrième mois de la grossesse et jusqu'au mois civil de la naissance de l'enfa
 champ d'application ÉligibilitéAllocationLogement:
   règle l_841_1_6_applicable rempli
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     l_841_1_6_applicable
     et selon ménage.situation_familiale sous forme
-    -- Célibataire :
-      nombre de ménage.personnes_à_charge = 0
-      et ménage.enfant_à_naître_après_quatrième_mois_grossesse
-    -- n'importe quel : faux
+      -- Célibataire :
+        nombre de ménage.personnes_à_charge = 0
+        et ménage.enfant_à_naître_après_quatrième_mois_grossesse
+      -- n'importe quel : faux
   conséquence rempli
 ```
 
@@ -1115,26 +1138,30 @@ champ d'application CalculetteAidesAuLogement:
   définition calcul_aide_personnalisée_logement.type_aide égal à
     TypeAidesPersonnelleLogement.AidePersonnaliséeLogement
   définition calcul_allocation_logement.type_aide égal à
-    (
-      selon éligibilité_allocation_logement.éligibilité sous forme
-      -- PasÉligible :
-        # Valeur par défaut, ne sera pas utilisée
-        TypeAidesPersonnelleLogement.AllocationLogementSociale
-      -- TypeÉligibilitéAllocationLogement.AllocationLogementFamiliale :
-        TypeAidesPersonnelleLogement.AllocationLogementFamiliale
-      -- TypeÉligibilitéAllocationLogement.AllocationLogementSociale :
-        TypeAidesPersonnelleLogement.AllocationLogementSociale
-    )
+  (
+    selon éligibilité_allocation_logement.éligibilité sous forme
+    -- PasÉligible :
+      # Valeur par défaut, ne sera pas utilisée
+      TypeAidesPersonnelleLogement.AllocationLogementSociale
+    -- TypeÉligibilitéAllocationLogement.AllocationLogementFamiliale :
+      TypeAidesPersonnelleLogement.AllocationLogementFamiliale
+    -- TypeÉligibilitéAllocationLogement.AllocationLogementSociale :
+      TypeAidesPersonnelleLogement.AllocationLogementSociale
+  )
 
   définition aide_finale_formule égal à
     si non éligibilité alors 0 €
-    sinon si éligibilité_aide_personnalisée_logement.éligibilité
-      et non (éligibilité_allocation_logement.éligibilité sous forme PasÉligible) alors
+    sinon si
+      éligibilité_aide_personnalisée_logement.éligibilité
+      et non (éligibilité_allocation_logement.éligibilité sous forme PasÉligible)
+    alors
       (
-        si calcul_aide_personnalisée_logement.traitement_aide_finale de
+        si
+          calcul_aide_personnalisée_logement.traitement_aide_finale de
             calcul_aide_personnalisée_logement.aide_finale_formule
           > calcul_allocation_logement.traitement_aide_finale de
-            calcul_allocation_logement.aide_finale_formule alors
+            calcul_allocation_logement.aide_finale_formule
+        alors
           calcul_aide_personnalisée_logement.aide_finale_formule
         sinon
           calcul_allocation_logement.aide_finale_formule
@@ -1152,8 +1179,10 @@ champ d'application CalculetteAidesAuLogement:
     dans
     si non éligibilité alors
       aide_finale
-    sinon si éligibilité_aide_personnalisée_logement.éligibilité
-      et non (éligibilité_allocation_logement.éligibilité sous forme PasÉligible) alors
+    sinon si
+      éligibilité_aide_personnalisée_logement.éligibilité
+      et non (éligibilité_allocation_logement.éligibilité sous forme PasÉligible)
+    alors
       (
         si aide_finale_apl > aide_finale_al alors
           aide_finale_apl
@@ -1183,20 +1212,20 @@ champ d'application ÉligibilitéAllocationLogement:
   # Idem avec l'exception prévue par L861-8. Nous écrivons donc l'assertion
   # ci-dessous pour matérialiser l'impossibilité de se retrouver dans ces
   # situations.
-  assertion non (
-    demandeur.personne_hébergée_centre_soin_l_L162_22_3_sécurité_sociale
-    et (
-      ménage.logement.mode_occupation sous forme AccessionPropriétéLocalUsageExclusifHabitation
-      ou demandeur.
-        magistrat_fonctionnaire_centre_intérêts_matériels_familiaux_hors_mayotte
+  assertion
+    non (
+      demandeur.personne_hébergée_centre_soin_l_L162_22_3_sécurité_sociale
+      et (
+        ménage.logement.mode_occupation sous forme AccessionPropriétéLocalUsageExclusifHabitation
+        ou demandeur.
+          magistrat_fonctionnaire_centre_intérêts_matériels_familiaux_hors_mayotte
+      )
     )
-  )
 
   exception base
   définition éligibilité
     état l841_2
-  sous condition
-    demandeur.personne_hébergée_centre_soin_l_L162_22_3_sécurité_sociale
+  sous condition demandeur.personne_hébergée_centre_soin_l_L162_22_3_sécurité_sociale
   conséquence égal à
     TypeÉligibilitéAllocationLogement.AllocationLogementSociale
 ```
@@ -1216,7 +1245,8 @@ champ d'application ÉligibilitéAllocationLogement:
     -- AccessionPropriétéLocalUsageExclusifHabitation contenu propriétaire :
       propriétaire.prêt.date_signature > |2017-12-31|
     -- n'importe quel : faux
-  conséquence égal à PasÉligible
+  conséquence égal à
+    PasÉligible
 ```
 
 ###### Article L841-5 | LEGIARTI000038814856
@@ -1295,7 +1325,8 @@ Saint-Pierre-et-Miquelon.
 # à l'allocation logement.
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
   exception
-  règle éligibilité sous condition
+  règle éligibilité
+  sous condition
     date_courante >= |2021-01-01|
     et ménage.résidence sous forme SaintPierreEtMiquelon
   conséquence non rempli
@@ -1332,8 +1363,8 @@ ne sont pas applicables à Mayotte.
 ```catala
 champ d'application ÉligibilitéPrimeDeDéménagement:
   exception
-  règle éligibilité sous condition
-    ménage.résidence sous forme Mayotte
+  règle éligibilité
+  sous condition ménage.résidence sous forme Mayotte
   conséquence non rempli
 ```
 
@@ -1353,8 +1384,8 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
   # de l'article L822-2 et ainsi adapter le droit pour son application à
   # Mayotte.
   exception
-  définition condition_nationalité sous condition
-    ménage.résidence sous forme Mayotte
+  définition condition_nationalité
+  sous condition ménage.résidence sous forme Mayotte
   conséquence égal à
     selon demandeur.nationalité sous forme
     -- Française : faux
@@ -1396,8 +1427,8 @@ par voie réglementaire. " ;
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   exception
-  règle septième_alinéa_l823_1_applicable sous condition
-    ménage.résidence sous forme Mayotte
+  règle septième_alinéa_l823_1_applicable
+  sous condition ménage.résidence sous forme Mayotte
   conséquence non rempli
 ```
 
@@ -1431,17 +1462,18 @@ conditions sont fixées par voie réglementaire ;”.
 
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- Guadeloupe : vrai
+  -- Guyane : vrai
+  -- Martinique : vrai
+  -- LaRéunion : vrai
+  -- Mayotte : vrai
+  -- n'importe quel : faux
+):
   étiquette logement_foyer
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- RésidentLogementFoyer contenu location :
       location.conventionné_selon_règles_drom
@@ -1463,15 +1495,15 @@ a) Les 1°, 2° et 6° sont supprimés et les 3°, 4° et 5° deviennent les 1°
 
 ```catala
 champ d'application ÉligibilitéAllocationLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- Guadeloupe : vrai
+  -- Guyane : vrai
+  -- Martinique : vrai
+  -- LaRéunion : vrai
+  -- Mayotte : vrai
+  -- n'importe quel : faux
+):
 
   exception
   règle l_841_1_1_applicable non rempli
@@ -1504,17 +1536,18 @@ L. 512-3 du code de la sécurité sociale ;
 ```catala
 # Ressemble au 2° de L841-1 mais subtilement différent.
 champ d'application ÉligibilitéAllocationLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- Guadeloupe : vrai
+  -- Guyane : vrai
+  -- Martinique : vrai
+  -- LaRéunion : vrai
+  -- Mayotte : vrai
+  -- n'importe quel : faux
+):
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     nombre de
       (
         liste de personne_à_charge parmi ménage.personnes_à_charge
@@ -1544,18 +1577,18 @@ et de la pêche maritime ;
 # Les personnes mentionnées aux articles L. 781-8 et L. 781-46 du code rural
 # et de la pêche maritime sont les non-salariés agricoles.
 champ d'application ÉligibilitéAllocationLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- Guadeloupe : vrai
+  -- Guyane : vrai
+  -- Martinique : vrai
+  -- LaRéunion : vrai
+  -- Mayotte : vrai
+  -- n'importe quel : faux
+):
 
-  règle éligibilité_allocation_logement_familiale sous condition
-    demandeur.est_non_salarié_agricole_l781_8_l_781_46_code_rural
+  règle éligibilité_allocation_logement_familiale
+  sous condition demandeur.est_non_salarié_agricole_l781_8_l_781_46_code_rural
   conséquence rempli
 ```
 
@@ -1591,18 +1624,19 @@ l'impossibilité constatée de se livrer à une activité professionnelle. " ;
 # l'article R823-4 : il faut en effet que l'enfant soit en études ou
 # apprentissage, etc.
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- Guadeloupe : vrai
+  -- Guyane : vrai
+  -- Martinique : vrai
+  -- LaRéunion : vrai
+  -- Mayotte : vrai
+  -- n'importe quel : faux
+):
 
   exception r823_4_enfants
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     selon personne_à_charge sous forme
     -- EnfantÀCharge contenu enfant :
       enfant.obligation_scolaire sous forme Prestations_familiales.SituationObligationScolaire.Après
@@ -1626,15 +1660,15 @@ Mayotte. "
 
 ```catala
 champ d'application ÉligibilitéAllocationLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- Guadeloupe : vrai
-    -- Guyane : vrai
-    -- Martinique : vrai
-    -- LaRéunion : vrai
-    -- Mayotte : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- Guadeloupe : vrai
+  -- Guyane : vrai
+  -- Martinique : vrai
+  -- LaRéunion : vrai
+  -- Mayotte : vrai
+  -- n'importe quel : faux
+):
   étiquette accession_propriété_outre_mer exception accession_propriété
   définition éligibilité
     état l841_2
@@ -1645,11 +1679,12 @@ champ d'application ÉligibilitéAllocationLogement
       ou (
         propriétaire.prêt.date_signature > |2019-12-31|
         et selon propriétaire.prêt.accord_financement_représentant_État_outre_mer sous forme
-        -- Accord contenu date_accord : date_accord <= |2018-12-31|
-        -- PasdAccord : faux
+          -- Accord contenu date_accord : date_accord <= |2018-12-31|
+          -- PasdAccord : faux
       )
     -- n'importe quel : faux
-  conséquence égal à PasÉligible
+  conséquence égal à
+    PasÉligible
 ```
 
 ####### Article L861-7 | LEGIARTI000038814773
@@ -1670,14 +1705,15 @@ matériels et familiaux est situé hors de Mayotte.
 
 ```catala
 champ d'application ÉligibilitéAllocationLogement
-  sous condition ménage.résidence sous forme Mayotte:
+sous condition ménage.résidence sous forme Mayotte:
   exception accession_propriété_outre_mer
   définition éligibilité
     état l841_2
   sous condition
     demandeur.
       magistrat_fonctionnaire_centre_intérêts_matériels_familiaux_hors_mayotte
-  conséquence égal à PasÉligible
+  conséquence égal à
+    PasÉligible
 ```
 ###### Section V : Contrôles, luttes contre la fraude et sanctions
 
@@ -1792,12 +1828,12 @@ les 1°, 2° et 3° ;
 # Nous faisons abstraction de ce contresens et raisonnons par analogie
 # en considérant qu'on fait ici la même chose que dans le a) de L816-6.
 champ d'application ÉligibilitéAllocationLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- SaintBarthélemy : vrai
+  -- SaintMartin : vrai
+  -- n'importe quel : faux
+):
 
   exception
   règle l_841_1_1_applicable non rempli
@@ -1817,14 +1853,15 @@ L. 512-3 du code de la sécurité sociale ;
 ```catala
 # Ressemble au 2° de L841-1 mais subtilement différent.
 champ d'application ÉligibilitéAllocationLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- SaintBarthélemy : vrai
+  -- SaintMartin : vrai
+  -- n'importe quel : faux
+):
 
-  règle éligibilité_allocation_logement_familiale sous condition
+  règle éligibilité_allocation_logement_familiale
+  sous condition
     nombre de
       (
         liste de personne_à_charge parmi ménage.personnes_à_charge
@@ -1854,15 +1891,15 @@ de la pêche maritime.
 # Les personnes mentionnées aux articles L. 781-8 et L. 781-46 du code rural
 # et de la pêche maritime sont les non-salariés agricoles.
 champ d'application ÉligibilitéAllocationLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- SaintBarthélemy : vrai
+  -- SaintMartin : vrai
+  -- n'importe quel : faux
+):
 
-  règle éligibilité_allocation_logement_familiale sous condition
-    demandeur.est_non_salarié_agricole_l781_8_l_781_46_code_rural
+  règle éligibilité_allocation_logement_familiale
+  sous condition demandeur.est_non_salarié_agricole_l781_8_l_781_46_code_rural
   conséquence rempli
 ```
 
@@ -1881,15 +1918,16 @@ constatée de se livrer à une activité professionnelle. " ;
 # l'article R823-4 : il faut en effet que l'enfant soit en études ou
 # apprentissage, etc.
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition (
-    selon ménage.résidence sous forme
-    -- SaintBarthélemy : vrai
-    -- SaintMartin : vrai
-    -- n'importe quel : faux
-  ):
+sous condition (
+  selon ménage.résidence sous forme
+  -- SaintBarthélemy : vrai
+  -- SaintMartin : vrai
+  -- n'importe quel : faux
+):
 
   exception r823_4_enfants
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     selon personne_à_charge sous forme
     -- EnfantÀCharge contenu enfant :
       enfant.obligation_scolaire sous forme Prestations_familiales.SituationObligationScolaire.Après
@@ -1935,10 +1973,10 @@ applicables à Saint-Pierre-et-Miquelon.
 
 ```catala
 champ d'application ÉligibilitéPrimeDeDéménagement
-  sous condition date_courante >= |2022-01-01|:
+sous condition date_courante >= |2022-01-01|:
   exception
-  règle éligibilité sous condition
-    ménage.résidence sous forme SaintPierreEtMiquelon
+  règle éligibilité
+  sous condition ménage.résidence sous forme SaintPierreEtMiquelon
   conséquence non rempli
 ```
 

--- a/tests/fr/code_construction_legislatif2.catala_fr
+++ b/tests/fr/code_construction_legislatif2.catala_fr
@@ -1,0 +1,22 @@
+```catala
+champ d'application ÉligibilitéAidesPersonnelleLogement:
+  étiquette cas_base_l822_4
+  règle condition_logement_location_tiers sous condition
+    ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme LouéOuSousLouéÀDesTiers.Non
+  conséquence non rempli
+
+  exception cas_base_l822_4
+  règle condition_logement_location_tiers sous condition
+    selon ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme
+    -- LouéOuSousLouéÀDesTiers.Non : vrai
+    -- LouéOuSousLouéÀDesTiers.Oui contenu personne :
+      (
+        résultat de France.VérificationÂgeSupérieurÀ avec {
+          -- date_naissance: personne.date_naissance_personne_sous_location
+          -- date_courante: date_courante
+          -- années: 30 an
+        }
+      ).est_supérieur
+      ou personne.conforme_article_l442_1
+  conséquence rempli
+```

--- a/tests/fr/code_construction_legislatif2.catala_fr.result
+++ b/tests/fr/code_construction_legislatif2.catala_fr.result
@@ -1,0 +1,23 @@
+```catala
+champ d'application ÉligibilitéAidesPersonnelleLogement:
+  étiquette cas_base_l822_4
+  règle condition_logement_location_tiers
+  sous condition ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme LouéOuSousLouéÀDesTiers.Non
+  conséquence non rempli
+
+  exception cas_base_l822_4
+  règle condition_logement_location_tiers
+  sous condition
+    selon ménage.logement.loué_ou_sous_loué_à_des_tiers sous forme
+    -- LouéOuSousLouéÀDesTiers.Non : vrai
+    -- LouéOuSousLouéÀDesTiers.Oui contenu personne :
+      (
+        résultat de France.VérificationÂgeSupérieurÀ avec {
+          -- date_naissance: personne.date_naissance_personne_sous_location
+          -- date_courante: date_courante
+          -- années: 30 an
+        }
+      ).est_supérieur
+      ou personne.conforme_article_l442_1
+  conséquence rempli
+```

--- a/tests/fr/code_construction_reglementaire.catala_fr.result
+++ b/tests/fr/code_construction_reglementaire.catala_fr.result
@@ -1027,7 +1027,8 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
     + nombre de ménage.personnes_à_charge
 
   étiquette base
-  règle condition_logement_surface sous condition
+  règle condition_logement_surface
+  sous condition
     soit condition_logement_surface_minimale_sans_seuil_m_carrés égal à
       (
         selon ménage.situation_familiale sous forme
@@ -1039,13 +1040,15 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
         -- ConcubinageDontSéparéDeFait : 16
       )
       + (
-        ménage.nombre_autres_occupants_logement
-        + nombre de ménage.personnes_à_charge
-      )
-      * 9
+          ménage.nombre_autres_occupants_logement
+          + nombre de ménage.personnes_à_charge
+        )
+        * 9
     dans
-    si condition_logement_surface_minimale_sans_seuil_m_carrés >= 70
-      et nombre_personnes_logement >= 8 alors
+    si
+      condition_logement_surface_minimale_sans_seuil_m_carrés >= 70
+      et nombre_personnes_logement >= 8
+    alors
       (ménage.logement.surface_m_carrés >= 70)
     sinon
       (
@@ -1124,7 +1127,7 @@ habituellement au foyer :
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2023-09-01|:
+sous condition date_courante >= |2023-09-01|:
   définition personnes_à_charge_prises_en_compte égal à
     liste de personne_à_charge parmi ménage.personnes_à_charge
       tel que prise_en_compte_personne_à_charge de personne_à_charge
@@ -1136,14 +1139,15 @@ l'article L. 823-2 du présent code ;
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2023-09-01|:
+sous condition date_courante >= |2023-09-01|:
   # L'âge limite de 21 ans établi ici vient écraser la valeur de l'âge limite
   # prévue par L512-3 du CSS et définie par défaut par R512-2 du CSS.
   étiquette r823_4_enfants
   définition prestations_familiales.âge_l512_3_2 égal à 21 an
 
   étiquette r823_4_enfants
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     selon personne_à_charge sous forme
     -- EnfantÀCharge contenu enfant :
       # Pour être considéré à charge pour les aides personnelles au logement,
@@ -1178,46 +1182,48 @@ code ;
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  règle condition_2_r823_4 de personne_à_charge sous condition
+  règle condition_2_r823_4 de personne_à_charge
+  sous condition
     date_courante >= |2023-09-01|
     et selon personne_à_charge sous forme
-    -- EnfantÀCharge contenu enfant : faux
-    -- AutrePersonneÀCharge contenu parent :
-      parent.parenté = Ascendant
-      et parent.ressources
-      <= plafond_individuel_l815_9_sécu * 1,25
-      et (
-        # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
-        # à détecter
-        (
-          parent.date_naissance
-          + âge_l351_8_1_sécu
-          <= date_courante
-          ou (
-            parent.titulaire_allocation_personne_âgée
-            et (
-              résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
-                -- date_naissance: parent.date_naissance
-                -- date_courante: date_courante
-                -- années: 65 an
-              }
-            ).est_inférieur_ou_égal
+      -- EnfantÀCharge contenu enfant : faux
+      -- AutrePersonneÀCharge contenu parent :
+        parent.parenté = Ascendant
+        et parent.ressources
+        <= plafond_individuel_l815_9_sécu * 1,25
+        et (
+          # VERIF: parent.date_naissance + âge_l351_8_1_sécu est ambiguë,
+          # à détecter
+          (
+            parent.date_naissance
+            + âge_l351_8_1_sécu
+            <= date_courante
+            ou (
+              parent.titulaire_allocation_personne_âgée
+              et (
+                  résultat de France.VérificationÂgeInférieurOuÉgalÀ avec {
+                    -- date_naissance: parent.date_naissance
+                    -- date_courante: date_courante
+                    -- années: 65 an
+                  }
+                ).est_inférieur_ou_égal
+            )
+          )
+          ou
+            # VERIF: parent.date_naissance + âge_l351_1_5_sécu est ambiguë,
+            # à détecter
+          (
+            parent.date_naissance
+            + âge_l351_1_5_sécu
+            <= date_courante
+            et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
           )
         )
-        ou
-        # VERIF: parent.date_naissance + âge_l351_1_5_sécu est ambiguë,
-        # à détecter
-        (
-          parent.date_naissance
-          + âge_l351_1_5_sécu
-          <= date_courante
-          et parent.bénéficiaire_l161_19_l351_8_l643_3_sécu
-        )
-      )
   conséquence rempli
 
   étiquette r823_4_2
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     # On utilise le si ... alors ... sinon pour éviter que l'appel de
     # la fonction "condition_2_r823_4" soit loggué deux fois lors
     # de l'évaluation des différentes justifications de l'arbre de défauts
@@ -1241,9 +1247,10 @@ au 31 décembre de l'année de référence multiplié par 1,25.
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2023-09-01|:
+sous condition date_courante >= |2023-09-01|:
   exception r823_4_2
-  règle prise_en_compte_personne_à_charge de personne_à_charge sous condition
+  règle prise_en_compte_personne_à_charge de personne_à_charge
+  sous condition
     selon personne_à_charge sous forme
     -- EnfantÀCharge contenu enfant : faux
     -- AutrePersonneÀCharge contenu parent :
@@ -1254,7 +1261,7 @@ champ d'application ÉligibilitéAidesPersonnelleLogement
       )
       et parent.incapacité_80_pourcent_ou_restriction_emploi
       et parent.ressources
-      <= plafond_individuel_l815_9_sécu * 1,25
+        <= plafond_individuel_l815_9_sécu * 1,25
   conséquence rempli
 ```
 
@@ -1449,11 +1456,11 @@ champ d'application CalculAllocationLogement:
   définition aide_finale_formule égal à
     sous_calcul_traitement.aide_finale_formule
   définition traitement_aide_finale de arg égal à
-    (
-      sous_calcul_traitement.
-        Traitement_formule_aide_finale.traitement_aide_finale de
-        arg
-    )
+  (
+    sous_calcul_traitement.
+      Traitement_formule_aide_finale.traitement_aide_finale de
+      arg
+  )
 
 champ d'application CalculAidePersonnaliséeLogement:
   définition catégorie_calcul_apl égal à
@@ -1470,11 +1477,11 @@ champ d'application CalculAidePersonnaliséeLogement:
   définition aide_finale_formule égal à
     sous_calcul_traitement.aide_finale_formule
   définition traitement_aide_finale de arg égal à
-    (
-      sous_calcul_traitement.
-        Traitement_formule_aide_finale.traitement_aide_finale de
-        arg
-    )
+  (
+    sous_calcul_traitement.
+      Traitement_formule_aide_finale.traitement_aide_finale de
+      arg
+  )
 ```
 
 ```catala
@@ -1884,9 +1891,9 @@ champ d'application CalculAidePersonnaliséeLogementLocatif:
   exception
   définition traitement_aide_finale
     de aide_finale état diminué
-  sous condition
-    bénéficiaire_aide_adulte_ou_enfant_handicapés
-  conséquence égal à aide_finale
+  sous condition bénéficiaire_aide_adulte_ou_enfant_handicapés
+  conséquence égal à
+    aide_finale
 
   assertion plafond_dégressivité_d823_16 >= plafond_loyer_d823_16_2 * 2,5
 ```
@@ -2105,7 +2112,8 @@ de la date d'emménagement.
 
 ```catala
 champ d'application ÉligibilitéPrimeDeDéménagement:
-  règle condition_rang_enfant sous condition
+  règle condition_rang_enfant
+  sous condition
     nombre de
       (
         liste de personne_à_charge parmi ménage.personnes_à_charge
@@ -2119,21 +2127,21 @@ champ d'application ÉligibilitéPrimeDeDéménagement:
     >= 3
   conséquence rempli
 
-  règle condition_période_déménagement sous condition
-    (
-      selon informations.date_naissance_troisième_enfant_ou_dernier_si_plus sous forme
-      -- MoinsDeTroisEnfants : faux
-      -- PlusDeTroisEnfants contenu date_naissance_ou_grossesse :
-        (
-          selon date_naissance_ou_grossesse sous forme
-          -- AvantPremierJourMoisCivilTroisièmeMoisDeGrossesse : faux
-          -- AprèsPremierJourMoisCivilTroisièmeMoisDeGrossesse : vrai
-          -- DateDeNaissance contenu date_naissance :
-            # VERIF: ambigü
-            date_courante
-            <= ((Date.premier_jour_du_mois de (date_naissance + 2 an))) + (-1 jour)
-        )
-    )
+  règle condition_période_déménagement
+  sous condition (
+    selon informations.date_naissance_troisième_enfant_ou_dernier_si_plus sous forme
+    -- MoinsDeTroisEnfants : faux
+    -- PlusDeTroisEnfants contenu date_naissance_ou_grossesse :
+      (
+        selon date_naissance_ou_grossesse sous forme
+        -- AvantPremierJourMoisCivilTroisièmeMoisDeGrossesse : faux
+        -- AprèsPremierJourMoisCivilTroisièmeMoisDeGrossesse : vrai
+        -- DateDeNaissance contenu date_naissance :
+          # VERIF: ambigü
+          date_courante
+          <= ((Date.premier_jour_du_mois de (date_naissance + 2 an))) + (-1 jour)
+      )
+  )
   conséquence rempli
 
   définition délai_après_emménagement_l823_8_2 égal à 6 mois
@@ -2236,14 +2244,14 @@ brut du loyer et des charges.
 
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéLoyer:
+sous condition mode_occupation_impayé sous forme ImpayéLoyer:
   définition montant_impayé égal à
     si montant_dette >= seuil_impayé_dépense_de_logement alors
       montant_dette
     sinon 0€
 
-  définition seuil_impayé_dépense_de_logement sous condition
-    aide_versée sous forme Bénéficiaire
+  définition seuil_impayé_dépense_de_logement
+  sous condition aide_versée sous forme Bénéficiaire
   conséquence égal à
     selon dépense_logement_brute sous forme
     -- Loyer contenu loyer_brut : (loyer_brut + montant_charges) * 2,0
@@ -2258,9 +2266,9 @@ d'une somme au moins égale à deux fois le montant mensuel net du loyer et des 
 
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéLoyer:
-  définition seuil_impayé_dépense_de_logement sous condition
-    aide_versée sous forme Bailleur
+sous condition mode_occupation_impayé sous forme ImpayéLoyer:
+  définition seuil_impayé_dépense_de_logement
+  sous condition aide_versée sous forme Bailleur
   conséquence égal à
     selon dépense_logement_nette sous forme
     -- Loyer contenu loyer_net : (loyer_net + montant_charges) * 2,0
@@ -2274,7 +2282,7 @@ Le montant mensuel brut du loyer correspond au loyer figurant dans le bail.
 ```catala
 # Il n'y a pas de montant de charge brut/net
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéLoyer:
+sous condition mode_occupation_impayé sous forme ImpayéLoyer:
   définition dépense_logement_brute égal à dépense_logement
 ```
 
@@ -2283,7 +2291,7 @@ montant de l'aide personnelle au logement.
 
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéLoyer:
+sous condition mode_occupation_impayé sous forme ImpayéLoyer:
   définition dépense_logement_nette égal à
     selon dépense_logement_brute sous forme
     -- Loyer contenu montant_loyer : Loyer contenu (montant_loyer - montant_apl)
@@ -2301,7 +2309,7 @@ champ d'application ImpayéDépenseLogement
 ```
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéPrêt:
+sous condition mode_occupation_impayé sous forme ImpayéPrêt:
 
   définition montant_impayé égal à
     si montant_dette >= seuil_impayé_dépense_de_logement alors
@@ -2324,10 +2332,10 @@ sixième du total annuel des échéances de prêt brutes ;
 
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéPrêt:
+sous condition mode_occupation_impayé sous forme ImpayéPrêt:
 
-  définition seuil_impayé_dépense_de_logement sous condition
-    aide_versée sous forme Bénéficiaire
+  définition seuil_impayé_dépense_de_logement
+  sous condition aide_versée sous forme Bénéficiaire
   conséquence égal à
     selon dépense_logement_brute sous forme
     -- Loyer : 0€ # Ne devrait pas arriver
@@ -2350,10 +2358,10 @@ total annuel des échéances de prêt nettes.
 
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéPrêt:
+sous condition mode_occupation_impayé sous forme ImpayéPrêt:
 
-  définition seuil_impayé_dépense_de_logement sous condition
-    aide_versée sous forme ÉtablissementHabilité
+  définition seuil_impayé_dépense_de_logement
+  sous condition aide_versée sous forme ÉtablissementHabilité
   conséquence égal à
     selon dépense_logement_nette sous forme
     -- Loyer : 0€ # ne devrait pas arriver
@@ -2366,7 +2374,7 @@ L'échéance de prêt brute correspond à celle figurant dans le contrat de prê
 
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéPrêt:
+sous condition mode_occupation_impayé sous forme ImpayéPrêt:
   définition dépense_logement_brute égal à dépense_logement
 ```
 
@@ -2375,7 +2383,7 @@ personnelle au logement.
 
 ```catala
 champ d'application ImpayéDépenseLogement
-  sous condition mode_occupation_impayé sous forme ImpayéPrêt:
+sous condition mode_occupation_impayé sous forme ImpayéPrêt:
   définition dépense_logement_nette égal à
     selon dépense_logement sous forme
     -- Loyer contenu loyer : Loyer contenu loyer # ne devrait pas arriver
@@ -3038,7 +3046,8 @@ par l'article D. 331-64.
 
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
-  règle caractéristiques_prêt_l831_1_1 de prêt sous condition
+  règle caractéristiques_prêt_l831_1_1 de prêt
+  sous condition
     prêt.titulaire_prêt sous forme Demandeur
     et (
       prêt.type_prêt sous forme D331_32
@@ -3075,7 +3084,8 @@ défini par les articles D. 331-76-1 et suivants et que ce dernier supporte les 
 
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
-  règle caractéristiques_prêt_l831_1_1 de prêt sous condition
+  règle caractéristiques_prêt_l831_1_1 de prêt
+  sous condition
     prêt.titulaire_prêt sous forme VendeurQuandDemandeurAContratLocationAccession
     et (
       prêt.type_prêt sous forme D331_59_8
@@ -3441,8 +3451,7 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
   exception
   définition plafond_mensualité_d832_10_3
     état base
-  sous condition
-    local_habité_première_fois_bénéficiaire
+  sous condition local_habité_première_fois_bénéficiaire
   conséquence égal à
     soit plafond_signature égal à
       calcul_plafond_mensualité_d832_10_3 de date_signature_prêt
@@ -3471,7 +3480,8 @@ selon la date de signature du contrat de prêt ou de location-accession ;
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
-  définition mensualité_minimale sous condition
+  définition mensualité_minimale
+  sous condition
     type_travaux_logement sous forme TravauxPourAcquisitionD832_15_1
     ou
     # Comment interpetéter le R832-5 dans
@@ -3505,7 +3515,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
             si
             # Pour la tranche supérieure
               ressources_ménage_arrondies
-              >= (montant_limite_tranches_d832_15_1 * n_nombre_parts_d832_11) alors
+              >= (montant_limite_tranches_d832_15_1 * n_nombre_parts_d832_11)
+            alors
               (
                 (
                   ressources_ménage_arrondies
@@ -3519,7 +3530,8 @@ champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
             si
             # Pour la tranche inférieure
               ressources_ménage_arrondies
-              <= montant_limite_tranches_d832_15_1 * n_nombre_parts_d832_11 alors
+              <= montant_limite_tranches_d832_15_1 * n_nombre_parts_d832_11
+            alors
               ressources_ménage_arrondies * taux_tranche_inférieure_d832_15_1
             sinon
               (
@@ -3540,8 +3552,8 @@ charges " E0 ".
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
-  définition mensualité_minimale sous condition
-    type_travaux_logement sous forme TravauxSurLogementDéjàAcquisD832_15_2
+  définition mensualité_minimale
+  sous condition type_travaux_logement sous forme TravauxSurLogementDéjàAcquisD832_15_2
   conséquence égal à
     calcul_équivalence_loyer_minimale.montant
 
@@ -3591,8 +3603,8 @@ alinéas du même article.
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
   exception
-  définition dépense_nette_minimale_d832_10 de allocation_mensuelle sous condition
-    date_signature_prêt >= |1999-06-30|
+  définition dépense_nette_minimale_d832_10 de allocation_mensuelle
+  sous condition date_signature_prêt >= |1999-06-30|
   conséquence égal à
     mensualité_principale + montant_forfaitaire_charges_d832_10
     - allocation_mensuelle
@@ -3615,13 +3627,15 @@ différence constatée.
 ```catala
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
   définition
-    abattement_dépense_nette_minimale_d832_10
-    de allocation_mensuelle égal à
+    abattement_dépense_nette_minimale_d832_10 de allocation_mensuelle
+  égal à
     soit dépense_nette_minimale égal à
       dépense_nette_minimale_d832_10 de allocation_mensuelle
     dans
-    si dépense_nette_minimale
-      <= ressources_ménage_avec_d832_18 * coefficient_multiplicateur_d832_17_3 alors
+    si
+      dépense_nette_minimale
+      <= ressources_ménage_avec_d832_18 * coefficient_multiplicateur_d832_17_3
+    alors
       ressources_ménage_avec_d832_18 * coefficient_multiplicateur_d832_17_3
       - dépense_nette_minimale
     sinon
@@ -3648,16 +3662,19 @@ et R. 822-13 à R. 822-17 .
 # Non, selon réponse de DGALN/DHUP/FE4 du 25/05/2022.
 champ d'application CalculAidePersonnaliséeLogementAccessionPropriété:
   définition ressources_ménage_avec_d832_18 égal à
-    si ressources_ménage_arrondies
+    si
+      ressources_ménage_arrondies
       <= mensualité_principale
-      * coefficient_multiplicateur_d832_18 alors
+      * coefficient_multiplicateur_d832_18
+    alors
       mensualité_principale * coefficient_multiplicateur_d832_18
     sinon ressources_ménage_arrondies
 
   exception
-  définition ressources_ménage_avec_d832_18 sous condition
-    situation_r822_11_13_17
-  conséquence égal à ressources_ménage_arrondies
+  définition ressources_ménage_avec_d832_18
+  sous condition situation_r822_11_13_17
+  conséquence égal à
+    ressources_ménage_arrondies
 ```
 
 ####### Article D832-19 | LEGIARTI000038878728
@@ -3707,7 +3724,8 @@ déclaration énumération TypeLogementFoyer:
 # "Autre" soient bien exclus de l'éligibilité à l'APL.
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
   exception logement_foyer
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- RésidentLogementFoyer contenu logement_foyer :
       logement_foyer.type_logement sous forme TypeLogementFoyer.Autre
@@ -3766,7 +3784,8 @@ remplacée par la convention prévue au III de l'article R. 353-159 .
 ```catala
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
   étiquette logement_foyer
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- RésidentLogementFoyer contenu logement_foyer :
       logement_foyer.remplit_conditions_r832_21
@@ -3934,9 +3953,9 @@ champ d'application CalculAidePersonnaliséeLogementFoyer:
       et date_conventionnement >= |1990-09-30|
     )
     ou selon type_logement_foyer sous forme
-    -- RésidenceSociale :
-      date_conventionnement >= |1994-12-31|
-    -- n'importe quel : faux
+      -- RésidenceSociale :
+        date_conventionnement >= |1994-12-31|
+      -- n'importe quel : faux
 ```
 
 1°
@@ -4055,8 +4074,7 @@ champ d'application CalculAidePersonnaliséeLogementFoyer:
   exception
   définition coefficient_prise_en_charge_d832_25
     état formule
-  sous condition
-    condition_2_du_832_25
+  sous condition condition_2_du_832_25
   conséquence égal à
     0,90
     - (
@@ -4074,8 +4092,7 @@ champ d'application CalculAidePersonnaliséeLogementFoyer:
   exception
   définition coefficient_prise_en_charge_d832_25
     état coeff_arrondi
-  sous condition
-    condition_2_du_832_25
+  sous condition condition_2_du_832_25
   conséquence égal à
     (
       arrondi de
@@ -4088,8 +4105,7 @@ champ d'application CalculAidePersonnaliséeLogementFoyer:
   exception
   définition coefficient_prise_en_charge_d832_25
     état seuil
-  sous condition
-    condition_2_du_832_25
+  sous condition condition_2_du_832_25
   conséquence égal à
     si coefficient_prise_en_charge_d832_25 >= 0,90 alors 0,90
     sinon
@@ -4117,8 +4133,8 @@ majoration par personne à charge supplémentaire	             0,5
 ```catala
 champ d'application CalculNombrePartLogementFoyer:
   exception
-  définition n_nombre_parts_d832_25_base sous condition
-    condition_2_du_832_25
+  définition n_nombre_parts_d832_25_base
+  sous condition condition_2_du_832_25
   conséquence égal à
     si nombre_personnes_à_charge = 0 alors
       selon situation_familiale_calcul_apl sous forme
@@ -4135,8 +4151,8 @@ champ d'application CalculNombrePartLogementFoyer:
       4,3
 
   étiquette d832_25_2 exception d832_25_1
-  définition n_nombre_parts_d832_25_majoration sous condition
-    condition_2_du_832_25
+  définition n_nombre_parts_d832_25_majoration
+  sous condition condition_2_du_832_25
   conséquence égal à
     si nombre_personnes_à_charge > 4 alors
       0,5 * (décimal de (nombre_personnes_à_charge - 4))
@@ -4207,7 +4223,7 @@ champ d'application CalculÉquivalenceLoyerMinimale:
             )
           )
           + décimal de montant_forfaitaire_d832_26
-          * n_nombre_parts_d832_25
+            * n_nombre_parts_d832_25
         )
         / 12,0
       )
@@ -4225,8 +4241,8 @@ douze.
 ```catala
 champ d'application CalculÉquivalenceLoyerMinimale:
   exception
-  définition montant sous condition
-    condition_2_du_832_25
+  définition montant
+  sous condition condition_2_du_832_25
   conséquence égal à
     soit ressources_ménage_arrondies égal à
       décimal de ressources_ménage_arrondies
@@ -4279,13 +4295,13 @@ l'aide est égal à la différence constatée.
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer:
   définition
-    dépense_nette_minimale_d832_27
-    de allocation_mensuelle égal à
+    dépense_nette_minimale_d832_27 de allocation_mensuelle
+  égal à
     équivalence_loyer_éligible - allocation_mensuelle
 
   définition
-    abattement_dépense_nette_minimale_d832_27
-    de allocation_mensuelle égal à
+    abattement_dépense_nette_minimale_d832_27 de allocation_mensuelle
+  égal à
     soit dépense_nette_minimale égal à
       dépense_nette_minimale_d832_27 de allocation_mensuelle
     dans
@@ -4446,7 +4462,8 @@ du 3° de l'article L. 823-1 .
 
 ```catala
 champ d'application CalculAllocationLogementLocatif
-  sous condition selon changement_logement_d842_4 sous forme
+sous condition
+  selon changement_logement_d842_4 sous forme
   -- Changement contenu infos :
     loyer_principal >= infos.ancien_loyer_principal
   -- PasDeChangement : faux:
@@ -4480,7 +4497,8 @@ L'allocation de logement est accordée au titre de la résidence principale :
 # article.
 # TODO juridique: vérifier si cela s'applique à la location-accession ou pas
 champ d'application ÉligibilitéAllocationLogement:
-  règle condition_accession_propriété sous condition
+  règle condition_accession_propriété
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- AccessionPropriétéLocalUsageExclusifHabitation : faux
     -- n'importe quel : vrai
@@ -4511,7 +4529,8 @@ conditions de décence ;
 # les travaux arrivent ultérieurement, dans ce cas c’est le 2°."
 champ d'application ÉligibilitéAllocationLogement:
   exception
-  règle condition_accession_propriété sous condition
+  règle condition_accession_propriété
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- AccessionPropriétéLocalUsageExclusifHabitation contenu propriétaire :
       propriétaire.prêt.titulaire_prêt sous forme Demandeur
@@ -4529,7 +4548,8 @@ figurant sur la liste mentionnée à l'article R. 321-15 ;
 ```catala
 champ d'application ÉligibilitéAllocationLogement:
   exception
-  règle condition_accession_propriété sous condition
+  règle condition_accession_propriété
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- AccessionPropriétéLocalUsageExclusifHabitation contenu propriétaire :
       propriétaire.prêt.titulaire_prêt sous forme Demandeur
@@ -4546,7 +4566,8 @@ mentionnés à l'article D. 331-63 .
 ```catala
 champ d'application ÉligibilitéAllocationLogement:
   exception
-  règle condition_accession_propriété sous condition
+  règle condition_accession_propriété
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- AccessionPropriétéLocalUsageExclusifHabitation contenu propriétaire :
       propriétaire.prêt.titulaire_prêt sous forme Demandeur
@@ -4768,8 +4789,8 @@ pour la première fois par l'allocataire.
 # le local est habité pour la première fois par le bénéficiaire.
 champ d'application CalculAllocationLogementAccessionPropriété:
   exception
-  définition plafond_mensualité_d842_6 sous condition
-    local_habité_première_fois_bénéficiaire
+  définition plafond_mensualité_d842_6
+  sous condition local_habité_première_fois_bénéficiaire
   conséquence égal à
     soit plafond_signature égal à
       calcul_plafond_mensualité_d842_6 de
@@ -4824,8 +4845,8 @@ des charges, le montant mensuel de l'allocation calculé selon les dispositions 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété:
   définition
-    dépense_nette_minimale
-    de allocation_mensuelle égal à
+    dépense_nette_minimale de allocation_mensuelle
+  égal à
     charges_mensuelles_prêt + montant_forfaitaire_charges
     - allocation_mensuelle
 ```
@@ -4837,8 +4858,8 @@ constatée.
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété:
   définition
-    abattement_dépense_nette_minimale
-    de allocation_mensuelle égal à
+    abattement_dépense_nette_minimale de allocation_mensuelle
+  égal à
     soit dépense_nette_minimale égal à
       dépense_nette_minimale de allocation_mensuelle
     dans
@@ -4858,7 +4879,8 @@ par arrêté.
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété:
-  règle condition_d842_11_3 sous condition
+  règle condition_d842_11_3
+  sous condition
     (
       type_travaux_logement sous forme TypeTravauxLogementR842_5.PasDeTravaux
       ou type_travaux_logement sous forme ObjectifDécenceLogement
@@ -4868,8 +4890,8 @@ champ d'application CalculAllocationLogementAccessionPropriété:
   conséquence rempli
 
   exception
-  définition seuil_minimal_dépense_nette_minimale sous condition
-    condition_d842_11_3
+  définition seuil_minimal_dépense_nette_minimale
+  sous condition condition_d842_11_3
   conséquence égal à
     ressources_ménage_arrondies * coefficient_d842_11
 ```
@@ -4890,21 +4912,21 @@ de l'article R. 842-5 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété:
-  définition seuil_minimal_ressources_ménage sous condition
+  définition seuil_minimal_ressources_ménage
+  sous condition (
     (
-      (
-        date_signature_prêt >= |1992-09-30|
-        et date_signature_prêt <= |1994-09-30|
-      )
-      ou (
-        date_signature_prêt > |1994-09-30|
-        et (
-          type_travaux_logement sous forme TypeTravauxLogementR842_5.PasDeTravaux
-          ou type_travaux_logement sous forme ObjectifDécenceLogement
-          ou type_travaux_logement sous forme AgrandirOuRendreHabitableD331_63
-        )
+      date_signature_prêt >= |1992-09-30|
+      et date_signature_prêt <= |1994-09-30|
+    )
+    ou (
+      date_signature_prêt > |1994-09-30|
+      et (
+        type_travaux_logement sous forme TypeTravauxLogementR842_5.PasDeTravaux
+        ou type_travaux_logement sous forme ObjectifDécenceLogement
+        ou type_travaux_logement sous forme AgrandirOuRendreHabitableD331_63
       )
     )
+  )
   conséquence égal à
     mensualité_principale * coefficient_d842_12
 ```
@@ -4915,7 +4937,8 @@ l'article R. 842-5 ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété:
-  définition seuil_minimal_ressources_ménage sous condition
+  définition seuil_minimal_ressources_ménage
+  sous condition
     date_signature_prêt > |1994-09-30|
     et type_travaux_logement sous forme PrévuDansListeR321_15
   conséquence égal à
@@ -4941,8 +4964,7 @@ champ d'application CalculAllocationLogementAccessionPropriété:
   exception
   définition ressources_ménage_arrondies
     état seuil
-  sous condition
-    situation_r822_11_13_17
+  sous condition situation_r822_11_13_17
   conséquence égal à
     ressources_ménage_arrondies
 ```
@@ -4970,7 +4992,8 @@ application du III de l'article 12 de la loi n° 57-908 du 7 août 1957 tendant
 
 ```catala
 champ d'application ÉligibilitéAllocationLogement
-  sous condition selon ménage.logement.mode_occupation sous forme
+sous condition
+  selon ménage.logement.mode_occupation sous forme
   -- RésidentLogementFoyer contenu logement_foyer :
     logement_foyer.construit_application_loi_1957_12_III
   -- n'importe quel : faux:
@@ -5188,10 +5211,12 @@ le montant mensuel de l'aide est égal à la différence constatée.
 ```catala
 champ d'application CalculAllocationLogementFoyer:
   définition
-    abattement_dépense_nette_minimale
-    de allocation_mensuelle égal à
-    si dépense_nette_minimale de allocation_mensuelle
-      < montant_minimal_dépense_nette_d842_17 alors
+    abattement_dépense_nette_minimale de allocation_mensuelle
+  égal à
+    si
+      dépense_nette_minimale de allocation_mensuelle
+      < montant_minimal_dépense_nette_d842_17
+    alors
       montant_minimal_dépense_nette_d842_17
       - dépense_nette_minimale de allocation_mensuelle
     sinon
@@ -5485,14 +5510,16 @@ plus de deux personnes.
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   étiquette r_844_4 exception base
-  règle condition_logement_surface sous condition
+  règle condition_logement_surface
+  sous condition
     ménage.personnes_âgées_handicapées_foyer_r844_4
     et ménage.logement.surface_m_carrés
-    >= (si nombre_personnes_logement = 1 alors 9 sinon 16)
+      >= (si nombre_personnes_logement = 1 alors 9 sinon 16)
   conséquence rempli
 
   exception r_844_4
-  règle condition_logement_surface sous condition
+  règle condition_logement_surface
+  sous condition
     ménage.personnes_âgées_handicapées_foyer_r844_4
     et nombre_personnes_logement > 2
   conséquence non rempli
@@ -5566,7 +5593,8 @@ personnes et plus.
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   exception base
-  règle condition_logement_surface sous condition
+  règle condition_logement_surface
+  sous condition
     ménage.résidence sous forme Mayotte
     et soit condition_logement_surface_minimale_sans_seuil_m_carrés égal à
       (
@@ -5579,13 +5607,15 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
         -- ConcubinageDontSéparéDeFait : 13
       )
       + (
-        ménage.nombre_autres_occupants_logement
-        + nombre de ménage.personnes_à_charge
-      )
-      * 9
+          ménage.nombre_autres_occupants_logement
+          + nombre de ménage.personnes_à_charge
+        )
+        * 9
     dans
-    si condition_logement_surface_minimale_sans_seuil_m_carrés >= 54
-      et nombre_personnes_logement >= 9 alors
+    si
+      condition_logement_surface_minimale_sans_seuil_m_carrés >= 54
+      et nombre_personnes_logement >= 9
+    alors
       (ménage.logement.surface_m_carrés >= 54)
     sinon
       (
@@ -5713,10 +5743,10 @@ s'appliquent aux contributions et aux prestations dues à compter du 1er janvier
 
 ```catala
 champ d'application ÉligibilitéPrimeDeDéménagement
-  sous condition date_courante >= |2022-01-01|:
+sous condition date_courante >= |2022-01-01|:
   exception
-  règle éligibilité sous condition
-    ménage.résidence sous forme Mayotte
+  règle éligibilité
+  sous condition ménage.résidence sous forme Mayotte
   conséquence non rempli
 ```
 
@@ -5732,9 +5762,10 @@ logements très sociaux, en accession à la propriété aidée par l'Etat ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-04-05|:
+sous condition date_courante >= |2023-04-05|:
   exception
-  règle condition_d842_11_3 sous condition
+  règle condition_d842_11_3
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5767,9 +5798,10 @@ du 2° de l'article D. 832-25 est limitée à six enfants ;
 # Ici nous reprenons les chiffres de D832-25, à prendre en compte lorsque
 # ceux-ci seront modifiés
 champ d'application CalculNombrePartLogementFoyer
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
   exception d832_25_2
-  définition n_nombre_parts_d832_25_majoration sous condition
+  définition n_nombre_parts_d832_25_majoration
+  sous condition
     limitation_majoration_personnes_à_charge
     et nombre_personnes_à_charge > 6
   conséquence égal à
@@ -5784,9 +5816,9 @@ champ d'application CalculNombrePartLogementFoyer
 # "limitation_majoration_personnes_à_charge" similaire qui déclenche celle de
 # CalculNombrePartLogementFoyer. C'est ce que nous faisons ci-dessous.
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
-  règle calcul_nombre_parts.limitation_majoration_personnes_à_charge sous condition
-    limitation_majoration_personnes_à_charge
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
+  règle calcul_nombre_parts.limitation_majoration_personnes_à_charge
+  sous condition limitation_majoration_personnes_à_charge
   conséquence rempli
 
 # Maintenant que nous avons défini notre point d'entrée dans
@@ -5794,8 +5826,9 @@ champ d'application CalculAidePersonnaliséeLogementFoyer
 # CalculAllocationLogementAccessionPropriété à la manière de D842-6.
 # C'est chose faite ci-dessous.
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
-  règle calcul_apl_logement_foyer.limitation_majoration_personnes_à_charge sous condition
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
+  règle calcul_apl_logement_foyer.limitation_majoration_personnes_à_charge
+  sous condition
     selon résidence sous forme
     -- Guadeloupe : vrai
     -- Guyane : vrai
@@ -5812,9 +5845,10 @@ logements très sociaux, en accession à la propriété aidée par l'Etat ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
   exception
-  règle condition_d842_11_3 sous condition
+  règle condition_d842_11_3
+  sous condition
     (
       selon résidence sous forme
       -- Guadeloupe : vrai
@@ -5841,8 +5875,9 @@ du 2° de l'article D. 832-25 est limitée à six enfants.
 
 ```catala
 champ d'application CalculAllocationLogementFoyer
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
-  règle calcul_apl_logement_foyer.limitation_majoration_personnes_à_charge sous condition
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
+  règle calcul_apl_logement_foyer.limitation_majoration_personnes_à_charge
+  sous condition
     selon résidence sous forme
     -- Guadeloupe : vrai
     -- Guyane : vrai
@@ -5874,17 +5909,18 @@ fixé à vingt-deux ans.
 # s'appliquerait qu'aux AL.
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   exception r823_4_enfants
-  définition prestations_familiales.âge_l512_3_2 sous condition
-    (
-      selon ménage.résidence sous forme
-      -- Guadeloupe : vrai
-      -- Guyane : vrai
-      -- Martinique : vrai
-      -- LaRéunion : vrai
-      -- Mayotte : vrai
-      -- n'importe quel : faux
-    )
-  conséquence égal à 22 an
+  définition prestations_familiales.âge_l512_3_2
+  sous condition (
+    selon ménage.résidence sous forme
+    -- Guadeloupe : vrai
+    -- Guyane : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- n'importe quel : faux
+  )
+  conséquence égal à
+    22 an
 ```
 
 ###### Article D861-10 | LEGIARTI000047985420
@@ -5943,16 +5979,18 @@ Pour leur application en Guadeloupe, en Guyane, en Martinique, à La Réunion et
 # janvier 1995. On vient donc raffiner la condition d'exclusion de
 # "condition_logement_bailleur".
 champ d'application ÉligibilitéAidePersonnaliséeLogement
-  sous condition date_courante >= |2023-04-05|
+sous condition
+  date_courante >= |2023-04-05|
   et selon ménage.résidence sous forme
-  -- Guadeloupe : vrai
-  -- Guyane : vrai
-  -- Martinique : vrai
-  -- LaRéunion : vrai
-  -- Mayotte : vrai
-  -- n'importe quel : faux:
+    -- Guadeloupe : vrai
+    -- Guyane : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- n'importe quel : faux:
   exception logement_foyer
-  règle condition_logement_bailleur sous condition
+  règle condition_logement_bailleur
+  sous condition
     selon ménage.logement.mode_occupation sous forme
     -- RésidentLogementFoyer contenu logement_foyer :
       logement_foyer.type_logement sous forme FoyerJeunesTravailleursOuMigrantsConventionnéL353_2Avant1995
@@ -6007,14 +6045,15 @@ Pour leur application en Guadeloupe, en Guyane, en Martinique, à La Réunion et
 
 ```catala
 champ d'application CalculAidePersonnaliséeLogementFoyer
-  sous condition date_courante >= |2023-04-05|
+sous condition
+  date_courante >= |2023-04-05|
   et selon résidence sous forme
-  -- Guadeloupe : vrai
-  -- Guyane : vrai
-  -- Martinique : vrai
-  -- LaRéunion : vrai
-  -- Mayotte : vrai
-  -- n'importe quel : faux:
+    -- Guadeloupe : vrai
+    -- Guyane : vrai
+    -- Martinique : vrai
+    -- LaRéunion : vrai
+    -- Mayotte : vrai
+    -- n'importe quel : faux:
   exception
   définition condition_2_du_832_25 égal à
     faux
@@ -6089,15 +6128,17 @@ présent code " ;
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= date_entrée_vigueur_différée_cch:
+sous condition date_courante >= date_entrée_vigueur_différée_cch:
 
   exception r823_4_enfants
-  définition prestations_familiales.âge_l512_3_2 sous condition
+  définition prestations_familiales.âge_l512_3_2
+  sous condition
     selon ménage.résidence sous forme
     -- SaintBarthélemy : vrai
     -- SaintMartin : vrai
     -- n'importe quel : faux
-  conséquence égal à 22 an
+  conséquence égal à
+    22 an
 ```
 
 3° Au 2° de l'article R. 823-11 , les mots : " définies au I de l'article L. 521-2 du
@@ -6146,8 +6187,8 @@ champ d'application ÉligibilitéAidesPersonnelleLogement:
   définition date_entrée_vigueur_différée_cch égal à |2021-01-01|
 
 champ d'application ÉligibilitéAidePersonnaliséeLogement:
-  définition éligibilité_commune.date_entrée_vigueur_différée_cch sous condition
-    ménage.logement.mode_occupation sous forme AccessionPropriétéLocalUsageExclusifHabitation
+  définition éligibilité_commune.date_entrée_vigueur_différée_cch
+  sous condition ménage.logement.mode_occupation sous forme AccessionPropriétéLocalUsageExclusifHabitation
   conséquence égal à
     |2021-05-01|
 ```
@@ -6288,9 +6329,10 @@ logements très sociaux, en accession à la propriété aidée par l'Etat ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2023-04-05|:
+sous condition date_courante >= |2023-04-05|:
   exception
-  règle condition_d842_11_3 sous condition
+  règle condition_d842_11_3
+  sous condition
     (
       selon résidence sous forme
       -- SaintBarthélemy : vrai
@@ -6323,8 +6365,9 @@ au d du 2° de l'article D. 832-25 est limitée à six enfants ;
 ```catala
 # Dispositif déjà codé dans D861-8, ici on l'active succintement.
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
-  règle calcul_apl_logement_foyer.limitation_majoration_personnes_à_charge sous condition
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
+  règle calcul_apl_logement_foyer.limitation_majoration_personnes_à_charge
+  sous condition
     selon résidence sous forme
     -- SaintBarthélemy : vrai
     -- SaintMartin : vrai
@@ -6338,9 +6381,10 @@ logements très sociaux, en accession à la propriété aidée par l'Etat ;
 
 ```catala
 champ d'application CalculAllocationLogementAccessionPropriété
-  sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
+sous condition date_courante >= |2019-09-01| et date_courante < |2023-04-05|:
   exception
-  règle condition_d842_11_3 sous condition
+  règle condition_d842_11_3
+  sous condition
     (
       selon résidence sous forme
       -- SaintBarthélemy : vrai
@@ -6764,11 +6808,11 @@ D. 823-19 et par les règles particulières figurant aux articles D. 842-1 à D.
 # personnalisée au logement.
 
 champ d'application CalculAllocationLogement
-  sous condition résidence sous forme SaintPierreEtMiquelon:
+sous condition résidence sous forme SaintPierreEtMiquelon:
 
   exception
-  définition sous_calcul_traitement sous condition
-    catégorie_calcul_apl sous forme LogementFoyer
+  définition sous_calcul_traitement
+  sous condition catégorie_calcul_apl sous forme LogementFoyer
   conséquence égal à
     selon catégorie_calcul_apl sous forme
     -- LogementFoyer contenu logement_foyer_ :
@@ -6830,7 +6874,8 @@ champ d'application CalculAllocationLogement
 déclaration traitement_nul_tout_le_temps
   contenu argent
   dépend de aide_finale contenu argent
-  égal à 0€
+  égal à
+    0€
 ```
 
 2° Au 5° de l'article D. 823-17, les mots : “ en fonction de l'évolution de l'indice des

--- a/tests/fr/code_sécurité_sociale.catala_fr.result
+++ b/tests/fr/code_sécurité_sociale.catala_fr.result
@@ -115,14 +115,15 @@ janvier 1968.
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition
+sous condition
   # Cette version de l'article est en vigueur depuis février 2025 seulement
   # mais la version précédente emporte les mêmes effets et était en vigueur
   # depuis le 1er septembre 2023.
   date_courante >= |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    date_naissance_assuré >= |1968-01-01|
-  conséquence égal à 64 an
+  définition âge_ouverture_droit
+  sous condition date_naissance_assuré >= |1968-01-01|
+  conséquence égal à
+    64 an
 
 champ d'application ÉligibilitéAidesPersonnelleLogement:
   définition ouverture_droits_retraite.date_naissance_assuré égal à
@@ -184,7 +185,8 @@ l'application de l'article L. 821-2.
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2023-09-01|
+sous condition
+  date_courante >= |2023-09-01|
   # L'article L351-1-5 du CCS est entré en vigueur au 1er septembre 2023,
   # aussi le code Catala appelé avec une date antérieure ne devrait pas avoir
   # besoin de cette valeur. Cependant, la sémantique de Catala fait que
@@ -216,7 +218,7 @@ de trois années ;
 
 ```catala
 champ d'application ÉligibilitéAidesPersonnelleLogement
-  sous condition date_courante >= |2023-09-01|:
+sous condition date_courante >= |2023-09-01|:
   définition âge_l351_8_1_sécu égal à âge_l161_17_2_sécu + 3 an
 ```
 
@@ -320,10 +322,11 @@ L'âge prévu au second alinéa de l'article L. 161-17-2 est fixé à :
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    date_naissance_assuré < |1951-07-01|
-  conséquence égal à 60 an
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition date_naissance_assuré < |1951-07-01|
+  conséquence égal à
+    60 an
 ```
 
 2° Soixante ans et quatre mois pour les assurés nés entre le 1er juillet
@@ -331,123 +334,138 @@ champ d'application OuvertureDroitsRetraite
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition
     date_naissance_assuré >= |1951-07-01|
     et date_naissance_assuré <= |1951-12-31|
-  conséquence égal à 60 an + 4 mois
+  conséquence égal à
+    60 an + 4 mois
 ```
 
 3° Soixante ans et neuf mois pour les assurés nés en 1952 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1952
-  conséquence égal à 60 an + 9 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1952
+  conséquence égal à
+    60 an + 9 mois
 ```
 
 4° Soixante et un ans et deux mois pour les assurés nés en 1953 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1953
-  conséquence égal à 61 an + 2 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1953
+  conséquence égal à
+    61 an + 2 mois
 ```
 
 5° Soixante et un ans et sept mois pour les assurés nés en 1954 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1954
-  conséquence égal à 61 an + 7 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1954
+  conséquence égal à
+    61 an + 7 mois
 ```
 
 6° Soixante-deux ans pour les assurés nés entre le 1er janvier 1955 et le 31 août 1961 inclus ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition
     date_naissance_assuré >= |1955-01-01|
     et date_naissance_assuré <= |1961-08-31|
-  conséquence égal à 62 an
+  conséquence égal à
+    62 an
 ```
 
 7° Soixante-deux ans et trois mois pour les assurés nés entre le 1er septembre 1961 et le 31 décembre 1961 inclus ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition
     date_naissance_assuré >= |1961-09-01|
     et date_naissance_assuré <= |1961-12-31|
-  conséquence égal à 62 an + 3 mois
+  conséquence égal à
+    62 an + 3 mois
 ```
 
 8° Soixante-deux ans et six mois pour les assurés nés en 1962 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1962
-  conséquence égal à 62 an + 6 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1962
+  conséquence égal à
+    62 an + 6 mois
 ```
 
 9° Soixante-deux ans et neuf mois pour les assurés nés en 1963 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1963
-  conséquence égal à 62 an + 9 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1963
+  conséquence égal à
+    62 an + 9 mois
 ```
 
 10° Soixante-trois ans pour les assurés nés en 1964 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1964
-  conséquence égal à 63 an
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1964
+  conséquence égal à
+    63 an
 ```
 
 11° Soixante-trois ans et trois mois pour les assurés nés en 1965 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1965
-  conséquence égal à 63 an + 3 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1965
+  conséquence égal à
+    63 an + 3 mois
 ```
 
 12° Soixante-trois ans et six mois pour les assurés nés en 1966 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1966
-  conséquence égal à 63 an + 6 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1966
+  conséquence égal à
+    63 an + 6 mois
 ```
 
 13° Soixante-trois ans et neuf mois pour les assurés nés en 1967 ;
 
 ```catala
 champ d'application OuvertureDroitsRetraite
-  sous condition date_courante > |2023-09-01|:
-  définition âge_ouverture_droit sous condition
-    Date.accès_année de date_naissance_assuré = 1967
-  conséquence égal à 62 an + 9 mois
+sous condition date_courante > |2023-09-01|:
+  définition âge_ouverture_droit
+  sous condition Date.accès_année de date_naissance_assuré = 1967
+  conséquence égal à
+    62 an + 9 mois
 ```
 
 14° Soixante-quatre ans pour les assurés nés à compter du 1er janvier 1968.
@@ -484,20 +502,26 @@ janvier 2019 et à 10 838,40 euros par an à compter du 1er janvier 2020 ;
 # l'éligibilité aux APL.
 
 champ d'application ÉligibilitéAidesPersonnelleLogement:
-  définition plafond_individuel_l815_9_sécu sous condition
+  définition plafond_individuel_l815_9_sécu
+  sous condition
     date_courante >= |2018-04-01|
     et date_courante < |2019-01-01|
-  conséquence égal à 9 998,40€
+  conséquence égal à
+    9 998,40€
 
-  définition plafond_individuel_l815_9_sécu sous condition
+  définition plafond_individuel_l815_9_sécu
+  sous condition
     date_courante >= |2019-01-01|
     et date_courante < |2020-01-01|
-  conséquence égal à 10 418,40€
+  conséquence égal à
+    10 418,40€
 
-  définition plafond_individuel_l815_9_sécu sous condition
+  définition plafond_individuel_l815_9_sécu
+  sous condition
     date_courante >= |2020-01-01|
     et date_courante < |2021-01-01|
-  conséquence égal à 10 838,40€
+  conséquence égal à
+    10 838,40€
 ```
 
 b) Lorsque les deux conjoints, concubins ou partenaires liés par un pacte civil

--- a/tests/fr/date_fr.catala_fr.result
+++ b/tests/fr/date_fr.catala_fr.result
@@ -6,12 +6,13 @@
 déclaration depuis_année_mois_jour
   contenu date
   dépend de
-  #[implicit_position_argument]
+    #[implicit_position_argument]
     pos contenu position_source,
     dyear contenu entier,
     dmonth contenu entier,
     dday contenu entier
-  égal à D.of_ymd de pos, dyear, dmonth, dday
+  égal à
+    D.of_ymd de pos, dyear, dmonth, dday
 
 déclaration vers_année_mois_jour
   contenu (entier, entier, entier)
@@ -22,22 +23,26 @@ déclaration vers_année_mois_jour
 déclaration dernier_jour_du_mois
   contenu date
   dépend de d contenu date
-  égal à D.last_day_of_month de d
+  égal à
+    D.last_day_of_month de d
 
 déclaration accès_année
   contenu entier
   dépend de d contenu date
-  égal à (vers_année_mois_jour de d).1
+  égal à
+    (vers_année_mois_jour de d).1
 
 déclaration accès_mois
   contenu entier
   dépend de d contenu date
-  égal à (vers_année_mois_jour de d).2
+  égal à
+    (vers_année_mois_jour de d).2
 
 déclaration accès_jour
   contenu entier
   dépend de d contenu date
-  égal à (vers_année_mois_jour de d).3
+  égal à
+    (vers_année_mois_jour de d).3
 
 déclaration premier_jour_du_mois
   contenu date

--- a/tests/fr/decrets_divers.catala_fr.result
+++ b/tests/fr/decrets_divers.catala_fr.result
@@ -19,26 +19,26 @@ sont supérieurs au plafond de base de 78 770 euros majoré de
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  définition plafond_I_d521_3 sous condition
-    date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
+  définition plafond_I_d521_3
+  sous condition date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
   conséquence égal à
     56 286 €
     + 5 628 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 
   exception
-  définition plafond_II_d521_3 sous condition
-    date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
+  définition plafond_II_d521_3
+  sous condition date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
   conséquence égal à
     78 770 €
     + 5 628 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 ```
 
 ## Instruction interministérielle n° DSS/SD2B/2018/279 du 17 décembre 2018 relative à la revalorisation au 1er janvier 2019 des plafonds de ressources d’attribution de certaines prestations familiales servies en métropole, en Guadeloupe, en Guyane, en Martinique, à la Réunion, à Saint-Barthélemy, à Saint-Martin et à Mayotte
@@ -60,26 +60,26 @@ base de 79 558 euros majoré de 5 684 euros par enfant à charge.
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  définition plafond_I_d521_3 sous condition
-    date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
+  définition plafond_I_d521_3
+  sous condition date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
   conséquence égal à
     56 849 €
     + 5 684 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 
   exception
-  définition plafond_II_d521_3 sous condition
-    date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
+  définition plafond_II_d521_3
+  sous condition date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
   conséquence égal à
     79 558 €
     + 5 684 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 ```
 
 ## Instruction interministerielle no DSS/SD2B/2019/261 du 18 décembre 2019 relative à la revalorisation au 1er janvier 2020 des plafonds de ressources d’attribution de certaines prestations familiales servies en métropole, en Guadeloupe, en Guyane, en Martinique, à La Réunion, à Saint-Barthélemy, à Saint-Martin et à Mayotte
@@ -101,26 +101,26 @@ tranche est celle dont les revenus sont supérieurs au plafond de base de
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  définition plafond_I_d521_3 sous condition
-    date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
+  définition plafond_I_d521_3
+  sous condition date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
   conséquence égal à
     57 759 €
     + 5 775 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 
   exception
-  définition plafond_II_d521_3 sous condition
-    date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
+  définition plafond_II_d521_3
+  sous condition date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
   conséquence égal à
     80 831 €
     + 5 775 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 ```
 
 ## Arrêté du 14 décembre 2020 relatif au montant des plafonds de ressources de certaines prestations familiales et aux tranches du barème applicable au recouvrement des indus et à la saisie des prestations
@@ -136,15 +136,15 @@ décembre 2021. Il est majoré de 5 827 euros par enfant à charge.
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  définition plafond_I_d521_3 sous condition
-    date_courante >= |2021-01-01| et date_courante <= |2021-12-31|
+  définition plafond_I_d521_3
+  sous condition date_courante >= |2021-01-01| et date_courante <= |2021-12-31|
   conséquence égal à
     58 279 €
     + 5 827 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 ```
 
 II. - Le plafond de ressources prévu au 2° du I des articles D. 521-1 et
@@ -156,15 +156,15 @@ décembre 2021. Il est majoré de 5 827 euros par enfant à charge.
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  définition plafond_II_d521_3 sous condition
-    date_courante >= |2021-01-01| et date_courante <= |2021-12-31|
+  définition plafond_II_d521_3
+  sous condition date_courante >= |2021-01-01| et date_courante <= |2021-12-31|
   conséquence égal à
     81 558 €
     + 5 827 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 ```
 
 # Dispositions spéciales relatives à Mayotte
@@ -178,7 +178,8 @@ pourcentage de la base mensuelle de calcul des allocations familiales
 prévue à l'article L. 551-1 du code de la sécurité sociale, ainsi qu'il suit :
 
 ```catala
-champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
+champ d'application AllocationsFamiliales
+sous condition résidence = Mayotte:
   # La formule change à Mayotte par rapport au cas général.
   exception
   définition montant_initial_base égal à
@@ -188,14 +189,15 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     + montant_initial_base_quatrième_enfant_et_plus_mayotte
 
   exception
-  règle droit_ouvert_base sous condition
-    (nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 1)
+  règle droit_ouvert_base
+  sous condition (nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 1)
   conséquence rempli
 ```
 
 1° 5,88 % pour un seul enfant à charge ;
 ```catala
-champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
+champ d'application AllocationsFamiliales
+sous condition résidence = Mayotte:
   étiquette mayotte exception base
   définition montant_initial_base_premier_enfant égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 0 alors
@@ -205,7 +207,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
 
 2° 32 % pour deux enfants à charge ;
 ```catala
-champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
+champ d'application AllocationsFamiliales
+sous condition résidence = Mayotte:
   étiquette mayotte exception base
   définition montant_initial_base_deuxième_enfant égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
@@ -280,11 +283,13 @@ A compter de 2021 57,28 €                  5,88 %                    32 %     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 ```catala
-champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
+champ d'application AllocationsFamiliales
+sous condition résidence = Mayotte:
 
   # Premier enfant
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2011-01-01|
     et date_courante <= |2011-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -294,7 +299,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2012-01-01|
     et date_courante <= |2012-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -304,7 +310,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2013-01-01|
     et date_courante <= |2013-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -314,7 +321,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2014-01-01|
     et date_courante <= |2014-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -324,7 +332,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2015-01-01|
     et date_courante <= |2015-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -334,7 +343,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2016-01-01|
     et date_courante <= |2016-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -344,7 +354,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2017-01-01|
     et date_courante <= |2017-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -354,7 +365,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2018-01-01|
     et date_courante <= |2018-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -364,7 +376,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2019-01-01|
     et date_courante <= |2019-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -374,7 +387,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     date_courante >= |2020-01-01|
     et date_courante <= |2020-12-31|
     et non avait_enfant_à_charge_avant_1er_janvier_2012
@@ -384,8 +398,8 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_premier_enfant sous condition
-    avait_enfant_à_charge_avant_1er_janvier_2012
+  définition montant_initial_base_premier_enfant
+  sous condition avait_enfant_à_charge_avant_1er_janvier_2012
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 0 alors
       57,28€
@@ -393,80 +407,80 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
 
   # Deuxième enfant
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2011-01-01| et date_courante <= |2011-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2011-01-01| et date_courante <= |2011-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 23,2%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2012-01-01| et date_courante <= |2012-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2012-01-01| et date_courante <= |2012-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 23,79%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2013-01-01| et date_courante <= |2013-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2013-01-01| et date_courante <= |2013-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 24,37%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2014-01-01| et date_courante <= |2014-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2014-01-01| et date_courante <= |2014-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 24,96%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2015-01-01| et date_courante <= |2015-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2015-01-01| et date_courante <= |2015-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 25,55%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2016-01-01| et date_courante <= |2016-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2016-01-01| et date_courante <= |2016-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 26,13%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2017-01-01| et date_courante <= |2017-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2017-01-01| et date_courante <= |2017-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 26,72%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 28,04%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 29,36%
     sinon 0 €
 
   exception mayotte
-  définition montant_initial_base_deuxième_enfant sous condition
-    date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
+  définition montant_initial_base_deuxième_enfant
+  sous condition date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
       bmaf.montant * 30,68%
@@ -474,80 +488,80 @@ champ d'application AllocationsFamiliales sous condition résidence = Mayotte:
 
   # Troisième enfant
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2011-01-01| et date_courante <= |2011-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2011-01-01| et date_courante <= |2011-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 4,63%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2012-01-01| et date_courante <= |2012-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2012-01-01| et date_courante <= |2012-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 5,39%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2013-01-01| et date_courante <= |2013-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2013-01-01| et date_courante <= |2013-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 6,15%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2014-01-01| et date_courante <= |2014-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2014-01-01| et date_courante <= |2014-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 6,90%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2015-01-01| et date_courante <= |2015-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2015-01-01| et date_courante <= |2015-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 7,66%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2016-01-01| et date_courante <= |2016-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2016-01-01| et date_courante <= |2016-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 8,42%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2017-01-01| et date_courante <= |2017-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2017-01-01| et date_courante <= |2017-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 9,18%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2018-01-01| et date_courante <= |2018-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 10,89%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2019-01-01| et date_courante <= |2019-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 12,59%
     sinon 0 €
 
   exception
-  définition montant_initial_base_troisième_enfant_mayotte sous condition
-    date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
+  définition montant_initial_base_troisième_enfant_mayotte
+  sous condition date_courante >= |2020-01-01| et date_courante <= |2020-12-31|
   conséquence égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 2 alors
       bmaf.montant * 14,30%

--- a/tests/fr/deficits_anterieurs.catala_fr.result
+++ b/tests/fr/deficits_anterieurs.catala_fr.result
@@ -12,13 +12,16 @@ champ d'application DéficitsAntérieurs1:
     résultat de Oracles.ImputationAuxDéficitsLesPlusAnciens avec {
       -- revenu_déclaré: 1000 €
       -- déficits_antérieurs:
-        [ Oracles.DéficitAntérieur {
+        [
+          Oracles.DéficitAntérieur {
             -- année: 2020
             -- valeur: 500 €
-          } ; Oracles.DéficitAntérieur {
+          };
+          Oracles.DéficitAntérieur {
             -- année: 2019
             -- valeur: 600 €
-          } ]
+          }
+        ]
     }
 ```
 

--- a/tests/fr/droit_successions.catala_fr.result
+++ b/tests/fr/droit_successions.catala_fr.result
@@ -54,17 +54,20 @@ ou un plus grand nombre.
 
 ```catala
 champ d'application RéserveHéréditaire:
-  définition quotité_réserve_héréditaire sous condition
-    nombre de enfants_réserve_héréditaire = 1
-  conséquence égal à 1,0 / 2,0
+  définition quotité_réserve_héréditaire
+  sous condition nombre de enfants_réserve_héréditaire = 1
+  conséquence égal à
+    1,0 / 2,0
 
-  définition quotité_réserve_héréditaire sous condition
-    nombre de enfants_réserve_héréditaire = 2
-  conséquence égal à 1,0 / 3,0
+  définition quotité_réserve_héréditaire
+  sous condition nombre de enfants_réserve_héréditaire = 2
+  conséquence égal à
+    1,0 / 3,0
 
-  définition quotité_réserve_héréditaire sous condition
-    nombre de enfants_réserve_héréditaire >= 3
-  conséquence égal à 1,0 / 4,0
+  définition quotité_réserve_héréditaire
+  sous condition nombre de enfants_réserve_héréditaire >= 3
+  conséquence égal à
+    1,0 / 4,0
 ```
 
 L'enfant qui renonce à la succession n'est compris dans le nombre d'enfants
@@ -101,9 +104,10 @@ conjoint survivant, non divorcé.
 
 ```catala
 champ d'application RéserveHéréditaire:
-  définition quotité_réserve_héréditaire sous condition
-    nombre de enfants_réserve_héréditaire = 0 et conjoint_survivant_non_divorcé
-  conséquence égal à 1,0 - (3,0 / 4,0)
+  définition quotité_réserve_héréditaire
+  sous condition nombre de enfants_réserve_héréditaire = 0 et conjoint_survivant_non_divorcé
+  conséquence égal à
+    1,0 - (3,0 / 4,0)
 ```
 
 NOTA:
@@ -117,9 +121,10 @@ par actes entre vifs ou testamentaires pourront épuiser la totalité des biens.
 
 ```catala
 champ d'application RéserveHéréditaire:
-  définition quotité_réserve_héréditaire sous condition
-    nombre de enfants_réserve_héréditaire = 0 et (non conjoint_survivant_non_divorcé)
-  conséquence égal à 0,0
+  définition quotité_réserve_héréditaire
+  sous condition nombre de enfants_réserve_héréditaire = 0 et (non conjoint_survivant_non_divorcé)
+  conséquence égal à
+    0,0
 ```
 
 ######## Article 917 | LEGIARTI000006433731
@@ -135,11 +140,11 @@ champ d'application RéserveHéréditaire:
   définition patrimoine_assiette_réserve_héréditaire égal à
     patrimoine_total
     - somme argent de (
-      transforme chaque bien parmi biens_usufruit_rente_viagère en
-        si bien.prise_en_compte_pour_réserve_héréditaire alors
-          0 €
-        sinon bien.valeur
-    )
+        transforme chaque bien parmi biens_usufruit_rente_viagère en
+          si bien.prise_en_compte_pour_réserve_héréditaire alors
+            0 €
+          sinon bien.valeur
+      )
 
   définition montant_réserve_héréditaire égal à
     patrimoine_assiette_réserve_héréditaire * quotité_réserve_héréditaire

--- a/tests/fr/epilogue.catala_fr.result
+++ b/tests/fr/epilogue.catala_fr.result
@@ -39,7 +39,7 @@ champ d'application AllocationsFamiliales:
   définition montant_versé_majoration égal à
     si droit_ouvert_base alors
       somme argent de
-      transforme chaque enfant parmi enfants_à_charge en montant_avec_garde_alternée_majoration de enfant
+        transforme chaque enfant parmi enfants_à_charge en montant_avec_garde_alternée_majoration de enfant
     sinon 0€
 
   définition montant_versé égal à

--- a/tests/fr/epilogue.catala_fr.result
+++ b/tests/fr/epilogue.catala_fr.result
@@ -23,9 +23,10 @@ champ d'application EnfantLePlusÂgé:
       }
 
 champ d'application AllocationsFamiliales:
-  définition montant_initial_métropole_majoration de enfant sous condition
-    non (droit_ouvert_majoration de enfant)
-  conséquence égal à 0 €
+  définition montant_initial_métropole_majoration de enfant
+  sous condition non (droit_ouvert_majoration de enfant)
+  conséquence égal à
+    0 €
 
   règle droit_ouvert_complément rempli
 
@@ -37,8 +38,8 @@ champ d'application AllocationsFamiliales:
     si droit_ouvert_base alors montant_avec_garde_alternée_base sinon 0€
   définition montant_versé_majoration égal à
     si droit_ouvert_base alors
-      somme argent
-        de transforme chaque enfant parmi enfants_à_charge en montant_avec_garde_alternée_majoration de enfant
+      somme argent de
+      transforme chaque enfant parmi enfants_à_charge en montant_avec_garde_alternée_majoration de enfant
     sinon 0€
 
   définition montant_versé égal à
@@ -87,14 +88,14 @@ champ d'application InterfaceAllocationsFamiliales:
   définition allocations_familiales.ressources_ménage égal à i_ressources_ménage
   définition allocations_familiales.résidence égal à i_résidence
   définition i_montant_versé égal à allocations_familiales.montant_versé
-  règle allocations_familiales.personne_charge_effective_permanente_est_parent sous condition
-    i_personne_charge_effective_permanente_est_parent
+  règle allocations_familiales.personne_charge_effective_permanente_est_parent
+  sous condition i_personne_charge_effective_permanente_est_parent
   conséquence rempli
-  règle allocations_familiales.personne_charge_effective_permanente_remplit_titre_I sous condition
-    i_personne_charge_effective_permanente_remplit_titre_I
+  règle allocations_familiales.personne_charge_effective_permanente_remplit_titre_I
+  sous condition i_personne_charge_effective_permanente_remplit_titre_I
   conséquence rempli
-  règle allocations_familiales.avait_enfant_à_charge_avant_1er_janvier_2012 sous condition
-    i_avait_enfant_à_charge_avant_1er_janvier_2012
+  règle allocations_familiales.avait_enfant_à_charge_avant_1er_janvier_2012
+  sous condition i_avait_enfant_à_charge_avant_1er_janvier_2012
   conséquence rempli
 ```
 

--- a/tests/fr/lfr_2022.catala_fr.result
+++ b/tests/fr/lfr_2022.catala_fr.result
@@ -42,7 +42,8 @@ de l'article 1417 du même code.
 champ d'application TraitementsSalairesDéclarant:
   définition assiette_exonérations_81_quater
     état art_5_lfr_2022
-  égal à assiette_exonérations_81_quater + revenus.pourboires_exonérés
+  égal à
+    assiette_exonérations_81_quater + revenus.pourboires_exonérés
 ```
 
 IV. - La perte de recettes résultant pour l'Etat du prolongement, du 31 décembre

--- a/tests/fr/modèle_convention_fiscale_ocde.catala_fr.result
+++ b/tests/fr/modèle_convention_fiscale_ocde.catala_fr.result
@@ -72,10 +72,12 @@ champ d'application TraitementsSalairesDéclarant:
     état convention_internationale
   égal à
     pensions_retraites_rentes_79
-    ++ [ PensionRetraiteRente {
+    ++ [
+      PensionRetraiteRente {
         -- valeur_initiale: revenus.pensions_étrangères_impôts_imputé
         -- type_pension: TypePensionRetraiteRente.PensionsRetraitesRentes
-      } ]
+      }
+    ]
 
 champ d'application TraitementsSalairesFoyerFiscal:
   définition rentes_viagères_titre_onéreux
@@ -83,26 +85,28 @@ champ d'application TraitementsSalairesFoyerFiscal:
   égal à
     rentes_viagères_titre_onéreux
     + somme argent de (
-      transforme chaque rente_viagère
-      parmi [ RenteViagèreOnéreux {
-          -- valeur: revenus.rentes_étrangères_imputables_percues_49moins_ans
-          -- catégorie: RenteViagèreOnéreuxMoins49Ans
-        } ;
-        RenteViagèreOnéreux {
-          -- valeur: revenus.rentes_étrangères_imputables_percues_50_59ans
-          -- catégorie: RenteViagèreOnéreuxEntre50Et59Ans
-        } ;
-        RenteViagèreOnéreux {
-          -- valeur: revenus.rentes_étrangères_imputables_percues_60_69ans
-          -- catégorie: RenteViagèreOnéreuxEntre60Et69Ans
-        } ;
-        RenteViagèreOnéreux {
-          -- valeur: revenus.rentes_étrangères_imputables_percues_70plus_ans
-          -- catégorie: RenteViagèreOnéreuxPlus70Ans
-        } ] en
-        rente_viagère.valeur
-        - calcul_déduction_rente_viagères_titre_onéreux de rente_viagère
-    )
+        transforme chaque rente_viagère
+        parmi [
+          RenteViagèreOnéreux {
+            -- valeur: revenus.rentes_étrangères_imputables_percues_49moins_ans
+            -- catégorie: RenteViagèreOnéreuxMoins49Ans
+          };
+          RenteViagèreOnéreux {
+            -- valeur: revenus.rentes_étrangères_imputables_percues_50_59ans
+            -- catégorie: RenteViagèreOnéreuxEntre50Et59Ans
+          };
+          RenteViagèreOnéreux {
+            -- valeur: revenus.rentes_étrangères_imputables_percues_60_69ans
+            -- catégorie: RenteViagèreOnéreuxEntre60Et69Ans
+          };
+          RenteViagèreOnéreux {
+            -- valeur: revenus.rentes_étrangères_imputables_percues_70plus_ans
+            -- catégorie: RenteViagèreOnéreuxPlus70Ans
+          }
+        ] en
+          rente_viagère.valeur
+          - calcul_déduction_rente_viagères_titre_onéreux de rente_viagère
+      )
 
 # Voir article 193 du CGI pour la justification du fait que les crédits
 # d'impôts sont calculés sur la base du revenu brut global ; il faut donc

--- a/tests/fr/nombre_de_parts.catala_fr.result
+++ b/tests/fr/nombre_de_parts.catala_fr.result
@@ -113,18 +113,18 @@ déclaration champ d'application NombreDeParts1:
 
 champ d'application NombreDeParts1:
   définition sortie égal à
-    (
-      résultat de IR.NombreDeParts avec {
-        -- foyer_fiscal:
-          (
-            résultat de Interface.DescriptionFoyerFiscal avec {
-              -- pacsées: vrai
-              -- nombre_enfants_à_charge_mineurs_et_non_mariés: 2
-            }
-          ).sortie
-        -- année_revenus: 2022
-      }
-    )
+  (
+    résultat de IR.NombreDeParts avec {
+      -- foyer_fiscal:
+        (
+          résultat de Interface.DescriptionFoyerFiscal avec {
+            -- pacsées: vrai
+            -- nombre_enfants_à_charge_mineurs_et_non_mariés: 2
+          }
+        ).sortie
+      -- année_revenus: 2022
+    }
+  )
 ```
 
 Le test ci-dessus doit donner le résultat suivant à l'exécution.
@@ -156,19 +156,19 @@ déclaration champ d'application NombreDeParts2:
 
 champ d'application NombreDeParts2:
   définition sortie égal à
-    (
-      résultat de IR.NombreDeParts avec {
-        -- foyer_fiscal:
-          (
-            résultat de Interface.DescriptionFoyerFiscal avec {
-              -- mariées: vrai
-              -- nombre_enfants_à_charge_mineurs_et_non_mariés: 3
-              -- titulaire_carte_invalidité_CMI_invalidité_40_pourcent: vrai
-            }
-          ).sortie
-        -- année_revenus: 2022
-      }
-    )
+  (
+    résultat de IR.NombreDeParts avec {
+      -- foyer_fiscal:
+        (
+          résultat de Interface.DescriptionFoyerFiscal avec {
+            -- mariées: vrai
+            -- nombre_enfants_à_charge_mineurs_et_non_mariés: 3
+            -- titulaire_carte_invalidité_CMI_invalidité_40_pourcent: vrai
+          }
+        ).sortie
+      -- année_revenus: 2022
+    }
+  )
 ```
 
 ### Analyse
@@ -328,21 +328,21 @@ déclaration champ d'application NombreDeParts3:
 
 champ d'application NombreDeParts3:
   définition sortie égal à
-    (
-      résultat de Interface .IR.NombreDeParts avec {
-        -- foyer_fiscal:
-          (
-            résultat de Interface.DescriptionFoyerFiscal avec {
-              -- veuve: vrai
-              -- pensionné_veuve_de_guerre: vrai
-              -- nombre_enfants_à_charge_mineurs_et_non_mariés: 1
-              -- nombre_enfants_majeurs_célibataires_sans_enfant: 2
-              -- nombre_enfants_majeurs_mariés_ou_chargés_famille: 1,5
-            }
-          ).sortie
-        -- année_revenus: 2022
-      }
-    )
+  (
+    résultat de Interface .IR.NombreDeParts avec {
+      -- foyer_fiscal:
+        (
+          résultat de Interface.DescriptionFoyerFiscal avec {
+            -- veuve: vrai
+            -- pensionné_veuve_de_guerre: vrai
+            -- nombre_enfants_à_charge_mineurs_et_non_mariés: 1
+            -- nombre_enfants_majeurs_célibataires_sans_enfant: 2
+            -- nombre_enfants_majeurs_mariés_ou_chargés_famille: 1,5
+          }
+        ).sortie
+      -- année_revenus: 2022
+    }
+  )
 ```
 
 ### Analyse
@@ -556,18 +556,18 @@ déclaration champ d'application NombreDeParts4:
 
 champ d'application NombreDeParts4:
   définition sortie égal à
-    (
-      résultat de Interface .IR.NombreDeParts avec {
-        -- foyer_fiscal:
-          (
-            résultat de Interface.DescriptionFoyerFiscal avec {
-              -- pacsées: vrai
-              -- nombre_enfants_à_charge_résidence_alternée: 1
-            }
-          ).sortie
-        -- année_revenus: 2022
-      }
-    )
+  (
+    résultat de Interface .IR.NombreDeParts avec {
+      -- foyer_fiscal:
+        (
+          résultat de Interface.DescriptionFoyerFiscal avec {
+            -- pacsées: vrai
+            -- nombre_enfants_à_charge_résidence_alternée: 1
+          }
+        ).sortie
+      -- année_revenus: 2022
+    }
+  )
 ```
 
 ### A - Sur le couple pacsé.
@@ -709,22 +709,22 @@ déclaration champ d'application NombreDeParts5:
 
 champ d'application NombreDeParts5:
   définition sortie égal à
-    (
-      résultat de IR.NombreDeParts avec {
-        -- foyer_fiscal:
-          (
-            résultat de Interface.DescriptionFoyerFiscal avec {
-              -- mariées: vrai
-              -- nombre_enfants_à_charge_mineurs_et_non_mariés: 2
-              # Attention ici il faut compter l'enfant 2 fois parce que la case
-              # CI dit "alternée DONT invalides"...
-              -- nombre_enfants_à_charge_résidence_alternée: 1
-              -- nombre_enfants_à_charge_résidence_alternée_invalides: 1
-            }
-          ).sortie
-        -- année_revenus: 2022
-      }
-    )
+  (
+    résultat de IR.NombreDeParts avec {
+      -- foyer_fiscal:
+        (
+          résultat de Interface.DescriptionFoyerFiscal avec {
+            -- mariées: vrai
+            -- nombre_enfants_à_charge_mineurs_et_non_mariés: 2
+            # Attention ici il faut compter l'enfant 2 fois parce que la case
+            # CI dit "alternée DONT invalides"...
+            -- nombre_enfants_à_charge_résidence_alternée: 1
+            -- nombre_enfants_à_charge_résidence_alternée_invalides: 1
+          }
+        ).sortie
+      -- année_revenus: 2022
+    }
+  )
 ```
 
 ## Calcul du nombre de parts du foyer fiscal

--- a/tests/fr/nombre_de_parts.catala_fr.result
+++ b/tests/fr/nombre_de_parts.catala_fr.result
@@ -329,7 +329,7 @@ déclaration champ d'application NombreDeParts3:
 champ d'application NombreDeParts3:
   définition sortie égal à
   (
-    résultat de Interface .IR.NombreDeParts avec {
+    résultat de Interface.IR.NombreDeParts avec {
       -- foyer_fiscal:
         (
           résultat de Interface.DescriptionFoyerFiscal avec {
@@ -557,7 +557,7 @@ déclaration champ d'application NombreDeParts4:
 champ d'application NombreDeParts4:
   définition sortie égal à
   (
-    résultat de Interface .IR.NombreDeParts avec {
+    résultat de Interface.IR.NombreDeParts avec {
       -- foyer_fiscal:
         (
           résultat de Interface.DescriptionFoyerFiscal avec {

--- a/tests/fr/oracles.catala_fr.result
+++ b/tests/fr/oracles.catala_fr.result
@@ -28,7 +28,8 @@ déclaration structure RésultatImputation:
 #      où l'on a diminué le déficit du montant imputé sur le revenu.
 déclaration imputation_aux_déficits_les_plus_anciens
   contenu RésultatImputation
-  dépend de revenu_déclaré contenu argent,
+  dépend de
+    revenu_déclaré contenu argent,
     déficits_antérieurs contenu liste de DéficitAntérieur
 ```
 
@@ -71,14 +72,16 @@ déclaration imputation_aux_déficits_les_plus_anciens
 #    uniformément possible dans la liste d'éléments.
 déclaration prorata_arrondi_euro
   contenu liste de argent
-  dépend de montant_à_distribuer contenu argent,
+  dépend de
+    montant_à_distribuer contenu argent,
     bases_prorata contenu liste de argent
 ```
 
 ```catala-metadata
 déclaration prorata_arrondi_euro_listes
   contenu liste de liste de argent
-  dépend de montant_à_distribuer contenu argent,
+  dépend de
+    montant_à_distribuer contenu argent,
     bases_prorata contenu liste de liste de argent
 ```
 
@@ -105,7 +108,8 @@ déclaration structure RésultatProRataArrondiEuroBranchement:
 
 déclaration prorata_arrondi_euro_branchement
   contenu RésultatProRataArrondiEuroBranchement
-  dépend de montant_à_distribuer contenu argent,
+  dépend de
+    montant_à_distribuer contenu argent,
     base_prorata_1 contenu optionnel de argent,
     base_prorata_2 contenu optionnel de argent,
     base_prorata_3 contenu optionnel de argent,

--- a/tests/fr/prologue.catala_fr.result
+++ b/tests/fr/prologue.catala_fr.result
@@ -22,7 +22,8 @@ déclaration énumération FraisRéels:
 
 déclaration plafond
   contenu argent
-  dépend de valeur contenu argent,
+  dépend de
+    valeur contenu argent,
     plafond contenu argent
   égal à
     si valeur > plafond alors plafond
@@ -30,7 +31,8 @@ déclaration plafond
 
 déclaration plancher
   contenu argent
-  dépend de valeur contenu argent,
+  dépend de
+    valeur contenu argent,
     plancher contenu argent
   égal à
     si valeur < plancher alors plancher

--- a/tests/fr/prorata.catala_fr.result
+++ b/tests/fr/prorata.catala_fr.result
@@ -11,7 +11,7 @@ champ d'application ProRata1:
   définition sortie égal à
     résultat de Oracles.ProRataArrondiEuro avec {
       -- montant_à_distribuer: 100 €
-      -- bases_prorata: [ 1 € ; 2 € ; 3 € ; 4 € ]
+      -- bases_prorata: [ 1 €; 2 €; 3 €; 4 € ]
     }
   assertion somme argent de sortie.valeurs_proratisées = 100 €
 ```
@@ -35,7 +35,7 @@ champ d'application ProRata2:
   définition sortie égal à
     résultat de Oracles.ProRataArrondiEuro avec {
       -- montant_à_distribuer: 15 €
-      -- bases_prorata: [ 1 € ; 2 € ; 3 € ; 4 € ]
+      -- bases_prorata: [ 1 €; 2 €; 3 €; 4 € ]
     }
   assertion somme argent de sortie.valeurs_proratisées = 15 €
 ```
@@ -59,7 +59,7 @@ champ d'application ProRata3:
   définition sortie égal à
     résultat de Oracles.ProRataArrondiEuro avec {
       -- montant_à_distribuer: 567 €
-      -- bases_prorata: [ 46 € ; 284 € ; 44 € ; 956 € ; 86 € ; 465 € ; 129 € ; 465 € ]
+      -- bases_prorata: [ 46 €; 284 €; 44 €; 956 €; 86 €; 465 €; 129 €; 465 € ]
     }
   assertion somme argent de sortie.valeurs_proratisées = 567 €
 ```

--- a/tests/fr/securite_sociale_D.catala_fr.result
+++ b/tests/fr/securite_sociale_D.catala_fr.result
@@ -32,7 +32,7 @@ b) 41 % pour le troisième enfant à charge et chacun des suivants.
 
 ```catala
 champ d'application AllocationsFamiliales
-  sous condition ressources_ménage <= plafond_I_d521_3:
+sous condition ressources_ménage <= plafond_I_d521_3:
 
   étiquette base
   définition montant_initial_base_deuxième_enfant égal à
@@ -55,10 +55,10 @@ prestations familiales ;
 
 ```catala
 champ d'application AllocationsFamiliales
-  sous condition ressources_ménage <= plafond_I_d521_3:
+sous condition ressources_ménage <= plafond_I_d521_3:
 
-  définition montant_initial_métropole_majoration de enfant sous condition
-    droit_ouvert_majoration de enfant
+  définition montant_initial_métropole_majoration de enfant
+  sous condition droit_ouvert_majoration de enfant
   conséquence égal à
     bmaf.montant * 16%
 ```
@@ -73,7 +73,8 @@ b) 20,5 % pour le troisième enfant à charge et chacun des suivants.
 
 ```catala
 champ d'application AllocationsFamiliales
-  sous condition (ressources_ménage > plafond_I_d521_3)
+sous condition
+  (ressources_ménage > plafond_I_d521_3)
   et (ressources_ménage <= plafond_II_d521_3):
 
   étiquette base
@@ -97,11 +98,12 @@ prestations familiales ;
 
 ```catala
 champ d'application AllocationsFamiliales
-  sous condition (ressources_ménage > plafond_I_d521_3)
+sous condition
+  (ressources_ménage > plafond_I_d521_3)
   et (ressources_ménage <= plafond_II_d521_3):
 
-  définition montant_initial_métropole_majoration de enfant sous condition
-    droit_ouvert_majoration de enfant
+  définition montant_initial_métropole_majoration de enfant
+  sous condition droit_ouvert_majoration de enfant
   conséquence égal à
     bmaf.montant * 8%
 ```
@@ -115,7 +117,7 @@ b) 10,25 % pour le troisième enfant à charge et chacun des suivants.
 
 ```catala
 champ d'application AllocationsFamiliales
-  sous condition ressources_ménage > plafond_II_d521_3:
+sous condition ressources_ménage > plafond_II_d521_3:
   étiquette base
   définition montant_initial_base_deuxième_enfant égal à
     si nombre de enfants_à_charge_droit_ouvert_prestation_familiale > 1 alors
@@ -137,10 +139,10 @@ prestations familiales.
 
 ```catala
 champ d'application AllocationsFamiliales
-  sous condition ressources_ménage > plafond_II_d521_3:
+sous condition ressources_ménage > plafond_II_d521_3:
 
-  définition montant_initial_métropole_majoration de enfant sous condition
-    droit_ouvert_majoration de enfant
+  définition montant_initial_métropole_majoration de enfant
+  sous condition droit_ouvert_majoration de enfant
   conséquence égal à
     bmaf.montant * 4%
 ```
@@ -165,7 +167,8 @@ champ d'application AllocationsFamiliales:
   # ressources.
 
   exception
-  définition complément_dégressif de allocation sous condition
+  définition complément_dégressif de allocation
+  sous condition
     (ressources_ménage > plafond_I_d521_3)
     et (ressources_ménage <= plafond_I_d521_3 + allocation * 12,0)
   conséquence égal à
@@ -173,7 +176,8 @@ champ d'application AllocationsFamiliales:
     * (1,0 / 12,0)
 
   exception
-  définition complément_dégressif de allocation sous condition
+  définition complément_dégressif de allocation
+  sous condition
     (ressources_ménage > plafond_II_d521_3)
     et (ressources_ménage <= plafond_II_d521_3 + allocation * 12,0)
   conséquence égal à
@@ -204,11 +208,11 @@ champ d'application AllocationsFamiliales:
   définition montant_versé_forfaitaire égal à
     montant_versé_forfaitaire_par_enfant
     * décimal de
-      nombre de
-        (
-          liste de enfant parmi enfants_à_charge
-            tel que droit_ouvert_forfaitaire de enfant
-        )
+        nombre de
+          (
+            liste de enfant parmi enfants_à_charge
+              tel que droit_ouvert_forfaitaire de enfant
+          )
 ```
 
 I.-Le montant mensuel de l'allocation forfaitaire prévue au deuxième alinéa de
@@ -225,10 +229,10 @@ de calcul des allocations familiales par enfant ;
 # forfaitaire. Erreur de rédaction ? Problème juridique ?
 
 champ d'application AllocationsFamiliales:
-  définition montant_versé_forfaitaire_par_enfant sous condition
-    ressources_ménage <= plafond_I_d521_3
+  définition montant_versé_forfaitaire_par_enfant
+  sous condition ressources_ménage <= plafond_I_d521_3
   conséquence égal à
-    (bmaf.montant * 20,234%)
+  (bmaf.montant * 20,234%)
 ```
 
 2° Lorsque le ménage ou la personne a disposé d'un montant de ressources
@@ -239,11 +243,12 @@ familiales par enfant ;
 
 ```catala
 champ d'application AllocationsFamiliales:
-  définition montant_versé_forfaitaire_par_enfant sous condition
+  définition montant_versé_forfaitaire_par_enfant
+  sous condition
     (ressources_ménage > plafond_I_d521_3)
     et (ressources_ménage <= plafond_II_d521_3)
   conséquence égal à
-    (bmaf.montant * 10,117%)
+  (bmaf.montant * 10,117%)
 ```
 
 3° Lorsque le ménage ou la personne a disposé d'un montant de ressources
@@ -253,10 +258,10 @@ des allocations familiales par enfant.
 
 ```catala
 champ d'application AllocationsFamiliales:
-  définition montant_versé_forfaitaire_par_enfant sous condition
-    ressources_ménage > plafond_II_d521_3
+  définition montant_versé_forfaitaire_par_enfant
+  sous condition ressources_ménage > plafond_II_d521_3
   conséquence égal à
-    (bmaf.montant * 5,059%)
+  (bmaf.montant * 5,059%)
 ```
 
 II.-En application du sixième alinéa de l'article L. 521-1, le montant mensuel
@@ -271,7 +276,8 @@ l'alinéa précédent et, d'autre part, le montant des ressources.
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  définition montant_versé_complément_pour_forfaitaire sous condition
+  définition montant_versé_complément_pour_forfaitaire
+  sous condition
     (ressources_ménage > plafond_I_d521_3)
     et (
       ressources_ménage
@@ -286,7 +292,8 @@ champ d'application AllocationsFamiliales:
     * (1,0 / 12,0)
 
   exception
-  définition montant_versé_complément_pour_forfaitaire sous condition
+  définition montant_versé_complément_pour_forfaitaire
+  sous condition
     (ressources_ménage > plafond_II_d521_3)
     et (
       ressources_ménage
@@ -322,10 +329,10 @@ champ d'application AllocationsFamiliales:
   définition plafond_I_d521_3 égal à
     55 950 €
     + 5 595 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 ```
 
 II.-Le plafond prévu au 2° du I des articles D. 521-1 et D. 521-2 est fixé à
@@ -336,10 +343,10 @@ champ d'application AllocationsFamiliales:
   définition plafond_II_d521_3 égal à
     78 300 €
     + 5 595 €
-    * (
-      décimal de
-        (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
-    )
+      * (
+        décimal de
+          (nombre de enfants_à_charge_droit_ouvert_prestation_familiale)
+      )
 ```
 
 III.-Les montants des plafonds et de leur majoration respective fixés au présent
@@ -377,7 +384,8 @@ fixé à 5,88 p. 100 de la base mensuelle prévue à l'article L. 755-3 .
 champ d'application AllocationsFamiliales:
 
   exception
-  définition montant_initial_base sous condition
+  définition montant_initial_base
+  sous condition
     prestations_familiales.régime_outre_mer_l751_1
     et nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1
   conséquence égal à
@@ -387,7 +395,8 @@ champ d'application AllocationsFamiliales:
   étiquette base définition montant_initial_base_premier_enfant égal à 0€
 
   exception base
-  définition montant_initial_base_premier_enfant sous condition
+  définition montant_initial_base_premier_enfant
+  sous condition
     prestations_familiales.régime_outre_mer_l751_1
     et (nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1)
   conséquence égal à
@@ -401,7 +410,8 @@ partir de onze ans et à 5,67 p. 100 à partir de seize ans.
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  définition montant_initial_majoration de enfant sous condition
+  définition montant_initial_majoration de enfant
+  sous condition
     (droit_ouvert_majoration de enfant)
     et prestations_familiales.régime_outre_mer_l751_1
     et (nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1)
@@ -413,7 +423,8 @@ champ d'application AllocationsFamiliales:
     bmaf.montant * 3,69%
 
   exception
-  définition montant_initial_majoration de enfant sous condition
+  définition montant_initial_majoration de enfant
+  sous condition
     (droit_ouvert_majoration de enfant)
     et prestations_familiales.régime_outre_mer_l751_1
     et (nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1)

--- a/tests/fr/securite_sociale_L.catala_fr.result
+++ b/tests/fr/securite_sociale_L.catala_fr.result
@@ -51,7 +51,8 @@ ouvre droit aux prestations familiales :
 ```catala
 champ d'application PrestationsFamiliales:
   étiquette cas_base
-  règle droit_ouvert de enfant sous condition
+  règle droit_ouvert de enfant
+  sous condition
     enfant.obligation_scolaire sous forme SituationObligationScolaire.Avant
     ou enfant.obligation_scolaire sous forme SituationObligationScolaire.Pendant
   conséquence rempli
@@ -63,7 +64,8 @@ tout enfant dont la rémunération éventuelle n'excède pas un plafond.
 ```catala
 champ d'application PrestationsFamiliales:
   étiquette cas_base
-  règle droit_ouvert de enfant sous condition
+  règle droit_ouvert de enfant
+  sous condition
     enfant.obligation_scolaire sous forme SituationObligationScolaire.Après
     et (enfant.rémuneration_mensuelle <= plafond_l512_3_2)
     et (enfant.date_de_naissance + âge_l512_3_2 > date_courante)
@@ -71,7 +73,8 @@ champ d'application PrestationsFamiliales:
 
   # On définit les conditions hors âge d'abord car elles
   # sont référencées plus tard dans l'article L521-1
-  règle conditions_hors_âge de enfant sous condition
+  règle conditions_hors_âge de enfant
+  sous condition
     (
       enfant.obligation_scolaire sous forme SituationObligationScolaire.Avant
       ou enfant.obligation_scolaire sous forme SituationObligationScolaire.Pendant
@@ -119,8 +122,8 @@ Les allocations familiales sont dues à partir du deuxième enfant à charge.
 
 ```catala
 champ d'application AllocationsFamiliales:
-  règle droit_ouvert_base sous condition
-    nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 2
+  règle droit_ouvert_base
+  sous condition nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 2
   conséquence rempli
 ```
 
@@ -134,13 +137,14 @@ celles de l'âge pour l'ouverture du droit aux allocations familiales.
 
 ```catala
 champ d'application AllocationsFamiliales:
-  règle droit_ouvert_forfaitaire de enfant sous condition
+  règle droit_ouvert_forfaitaire de enfant
+  sous condition
     # nombre_enfants_alinéa_2_l521_3 sera défini dans l'article R521-3
     (nombre de enfants_à_charge >= nombre_enfants_alinéa_2_l521_1)
     et
-    # Puisqu'un enfant ne garde un âge donné que pour une période d'un an,
-    # cette condition assure que l'allocation ne peut être distribuée que pour
-    # un an.
+      # Puisqu'un enfant ne garde un âge donné que pour une période d'un an,
+      # cette condition assure que l'allocation ne peut être distribuée que pour
+      # un an.
     (
       (enfant.date_de_naissance + prestations_familiales.âge_l512_3_2)
       - date_courante
@@ -182,13 +186,15 @@ que ce soit, la charge effective et permanente de l'enfant.
 
 ```catala
 champ d'application AllocationsFamiliales:
-  définition prise_en_compte de enfant sous condition
-    enfant.prise_en_charge sous forme EffectiveEtPermanente
-  conséquence égal à PriseEnCompte.Complète
+  définition prise_en_compte de enfant
+  sous condition enfant.prise_en_charge sous forme EffectiveEtPermanente
+  conséquence égal à
+    PriseEnCompte.Complète
 
-  définition versement de enfant sous condition
-    enfant.prise_en_charge sous forme EffectiveEtPermanente
-  conséquence égal à VersementAllocations.Normal
+  définition versement de enfant
+  sous condition enfant.prise_en_charge sous forme EffectiveEtPermanente
+  conséquence égal à
+    VersementAllocations.Normal
 ```
 
 En cas de résidence alternée de l'enfant au domicile de chacun des parents telle
@@ -202,23 +208,27 @@ les conditions d'application du présent alinéa.
 ```catala
 champ d'application AllocationsFamiliales:
   # Premier cas : garde alternée, parents désignent un unique allocataire
-  définition prise_en_compte de enfant sous condition
-    enfant.prise_en_charge sous forme GardeAlternéeAllocataireUnique
-  conséquence égal à PriseEnCompte.Complète
+  définition prise_en_compte de enfant
+  sous condition enfant.prise_en_charge sous forme GardeAlternéeAllocataireUnique
+  conséquence égal à
+    PriseEnCompte.Complète
 
-  définition versement de enfant sous condition
-    enfant.prise_en_charge sous forme GardeAlternéeAllocataireUnique
-  conséquence égal à VersementAllocations.Normal
+  définition versement de enfant
+  sous condition enfant.prise_en_charge sous forme GardeAlternéeAllocataireUnique
+  conséquence égal à
+    VersementAllocations.Normal
 
   # Deuxième cas : garde alternée, parents partagent la charge pour
   # l'allocation
-  définition prise_en_compte de enfant sous condition
-    enfant.prise_en_charge sous forme GardeAlternéePartageAllocations
-  conséquence égal à PriseEnCompte.Partagée
+  définition prise_en_compte de enfant
+  sous condition enfant.prise_en_charge sous forme GardeAlternéePartageAllocations
+  conséquence égal à
+    PriseEnCompte.Partagée
 
-  définition versement de enfant sous condition
-    enfant.prise_en_charge sous forme GardeAlternéePartageAllocations
-  conséquence égal à VersementAllocations.Normal
+  définition versement de enfant
+  sous condition enfant.prise_en_charge sous forme GardeAlternéePartageAllocations
+  conséquence égal à
+    VersementAllocations.Normal
 ```
 
 Lorsque la personne qui assume la charge effective et permanente de l'enfant ne
@@ -228,11 +238,12 @@ du droit aux allocations familiales, ce droit s'ouvre du chef du père ou,
 
 ```catala
 champ d'application AllocationsFamiliales:
-  assertion personne_charge_effective_permanente_est_parent
-  ou (
-    (non personne_charge_effective_permanente_est_parent)
-    et personne_charge_effective_permanente_remplit_titre_I
-  )
+  assertion
+    personne_charge_effective_permanente_est_parent
+    ou (
+      (non personne_charge_effective_permanente_est_parent)
+      et personne_charge_effective_permanente_remplit_titre_I
+    )
 ```
 
 Lorsqu'un enfant est confié au service d'aide sociale à l'enfance, les
@@ -249,21 +260,25 @@ l'enfant dans son foyer.
 
 ```catala
 champ d'application AllocationsFamiliales:
-  définition prise_en_compte de enfant sous condition
-    enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeAuxServicesSociaux
-  conséquence égal à PriseEnCompte.Zéro
+  définition prise_en_compte de enfant
+  sous condition enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeAuxServicesSociaux
+  conséquence égal à
+    PriseEnCompte.Zéro
 
-  définition versement de enfant sous condition
-    enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeAuxServicesSociaux
-  conséquence égal à VersementAllocations.AllocationVerséeAuxServicesSociaux
+  définition versement de enfant
+  sous condition enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeAuxServicesSociaux
+  conséquence égal à
+    VersementAllocations.AllocationVerséeAuxServicesSociaux
 
-  définition prise_en_compte de enfant sous condition
-    enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeÀLaFamille
-  conséquence égal à PriseEnCompte.Complète
+  définition prise_en_compte de enfant
+  sous condition enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeÀLaFamille
+  conséquence égal à
+    PriseEnCompte.Complète
 
-  définition versement de enfant sous condition
-    enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeÀLaFamille
-  conséquence égal à VersementAllocations.Normal
+  définition versement de enfant
+  sous condition enfant.prise_en_charge sous forme ServicesSociauxAllocationVerséeÀLaFamille
+  conséquence égal à
+    VersementAllocations.Normal
 ```
 
 Un décret en Conseil d'Etat fixe les conditions d'application du présent
@@ -297,7 +312,8 @@ d'un âge minimum à une majoration des allocations familiales.
 
 ```catala
 champ d'application AllocationsFamiliales:
-  règle droit_ouvert_majoration de enfant sous condition
+  règle droit_ouvert_majoration de enfant
+  sous condition
     (non (est_enfant_le_plus_âgé de enfant))
     et (
       enfant.date_de_naissance + âge_minimum_alinéa_1_l521_3 de enfant
@@ -313,7 +329,8 @@ de l'âge mentionné au premier alinéa.
 ```catala
 champ d'application AllocationsFamiliales:
   exception
-  règle droit_ouvert_majoration de enfant sous condition
+  règle droit_ouvert_majoration de enfant
+  sous condition
     (
       nombre de enfants_à_charge_droit_ouvert_prestation_familiale
       >= nombre_enfants_alinéa_2_l521_3
@@ -357,7 +374,8 @@ sociale, y compris les membres des professions agricoles.
 # générale de sécurité sociale et les membres des professions agricoles.
 
 champ d'application PrestationsFamiliales:
-  règle régime_outre_mer_l751_1 sous condition
+  règle régime_outre_mer_l751_1
+  sous condition
     (résidence = Guadeloupe)
     ou (résidence = Guyane)
     ou (résidence = Martinique)
@@ -417,7 +435,8 @@ effectivement la charge de celui-ci.
 
 champ d'application AllocationsFamiliales:
   exception
-  règle droit_ouvert_base sous condition
+  règle droit_ouvert_base
+  sous condition
     prestations_familiales.régime_outre_mer_l751_1
     et (nombre de enfants_à_charge_droit_ouvert_prestation_familiale >= 1)
   conséquence rempli
@@ -431,13 +450,15 @@ applicables lorsque le ménage ou la personne a un seul enfant à charge.
 
 champ d'application AllocationsFamiliales:
   exception
-  règle droit_ouvert_forfaitaire de enfant sous condition
+  règle droit_ouvert_forfaitaire de enfant
+  sous condition
     prestations_familiales.régime_outre_mer_l751_1
     et (nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1)
   conséquence non rempli
 
   exception
-  règle droit_ouvert_complément sous condition
+  règle droit_ouvert_complément
+  sous condition
     prestations_familiales.régime_outre_mer_l751_1
     et (nombre de enfants_à_charge_droit_ouvert_prestation_familiale = 1)
   conséquence non rempli

--- a/tests/fr/securite_sociale_R.catala_fr.result
+++ b/tests/fr/securite_sociale_R.catala_fr.result
@@ -77,8 +77,8 @@ champ d'application AllocationFamilialesAvril2008:
 
 champ d'application AllocationsFamiliales:
   exception
-  définition âge_minimum_alinéa_1_l521_3 de enfant sous condition
-    (enfant.date_de_naissance + 11 an <= |2008-04-30|)
+  définition âge_minimum_alinéa_1_l521_3 de enfant
+  sous condition (enfant.date_de_naissance + 11 an <= |2008-04-30|)
   conséquence égal à
     version_avril_2008.âge_minimum_alinéa_1_l521_3
 ```
@@ -186,8 +186,8 @@ alternée, le montant servi au titre de cette majoration est réduit de moitié.
 ```catala
 champ d'application AllocationsFamiliales:
   définition
-    montant_avec_garde_alternée_majoration
-    de enfant égal à
+    montant_avec_garde_alternée_majoration de enfant
+  égal à
     montant_initial_majoration de enfant
     * (
       selon (prise_en_compte de enfant) sous forme
@@ -216,8 +216,8 @@ multiplié par 169.
 ```catala
 champ d'application PrestationsFamiliales:
   exception
-  définition plafond_l512_3_2 sous condition
-    régime_outre_mer_l751_1
+  définition plafond_l512_3_2
+  sous condition régime_outre_mer_l751_1
   conséquence égal à
     (smic.brut_horaire * 55%) * 169,0
 ```

--- a/tests/fr/sécurité_sociale_L.catala_fr.result
+++ b/tests/fr/sécurité_sociale_L.catala_fr.result
@@ -49,7 +49,8 @@ ouvre droit aux prestations familiales :
 ```catala
 champ d'application ÉligibilitéPrestationsFamiliales:
   étiquette cas_base
-  règle droit_ouvert de enfant sous condition
+  règle droit_ouvert de enfant
+  sous condition
     enfant.obligation_scolaire sous forme Avant
     ou enfant.obligation_scolaire sous forme Pendant
   conséquence rempli
@@ -61,21 +62,23 @@ dont la rémunération éventuelle n'excède pas un plafond.
 ```catala
 champ d'application ÉligibilitéPrestationsFamiliales:
   étiquette cas_base
-  règle droit_ouvert de enfant sous condition
+  règle droit_ouvert de enfant
+  sous condition
     enfant.obligation_scolaire sous forme Après
     et (enfant.rémuneration_mensuelle <= plafond_l512_3_2)
     et (
-      résultat de France.VérificationÂgeSupérieurÀ avec {
-        -- date_naissance: enfant.date_de_naissance
-        -- date_courante: date_courante
-        -- années: âge_l512_3_2
-      }
-    ).est_supérieur
+        résultat de France.VérificationÂgeSupérieurÀ avec {
+          -- date_naissance: enfant.date_de_naissance
+          -- date_courante: date_courante
+          -- années: âge_l512_3_2
+        }
+      ).est_supérieur
   conséquence rempli
 
   # On définit les conditions hors âge d'abord car elles
   # sont référencées plus tard dans l'article L521-1
-  règle conditions_hors_âge de enfant sous condition
+  règle conditions_hors_âge de enfant
+  sous condition
     (
       enfant.obligation_scolaire sous forme Avant
       ou enfant.obligation_scolaire sous forme Pendant
@@ -127,7 +130,8 @@ sociale, y compris les membres des professions agricoles.
 # générale de sécurité sociale et les membres des professions agricoles.
 
 champ d'application ÉligibilitéPrestationsFamiliales:
-  règle régime_outre_mer_l751_1 sous condition
+  règle régime_outre_mer_l751_1
+  sous condition
     (résidence = Guadeloupe)
     ou (résidence = Guyane)
     ou (résidence = Martinique)

--- a/tests/fr/sécurité_sociale_R.catala_fr.result
+++ b/tests/fr/sécurité_sociale_R.catala_fr.result
@@ -56,8 +56,8 @@ multiplié par 169.
 ```catala
 champ d'application ÉligibilitéPrestationsFamiliales:
   exception
-  définition plafond_l512_3_2 sous condition
-    régime_outre_mer_l751_1
+  définition plafond_l512_3_2
+  sous condition régime_outre_mer_l751_1
   conséquence égal à
     (smic.brut_horaire * 55%) * 169,0
 ```

--- a/tests/fr/tests_allocations_familiales.catala_fr.result
+++ b/tests/fr/tests_allocations_familiales.catala_fr.result
@@ -65,7 +65,7 @@ déclaration champ d'application Test1:
 
 champ d'application Test1:
   définition f.i_enfants égal à
-    [ données.enfant1 ; données.enfant2 ; données.enfant3 ; données.enfant4 ]
+    [ données.enfant1; données.enfant2; données.enfant3; données.enfant4 ]
   définition f.i_ressources_ménage égal à 30 000 €
   définition f.i_date_courante égal à |2020-05-01|
   définition f.i_résidence égal à Métropole
@@ -79,7 +79,7 @@ déclaration champ d'application Test2:
 
 champ d'application Test2:
   définition f.i_enfants égal à
-    [ données.enfant1 ; données.enfant2 ; données.enfant5 ]
+    [ données.enfant1; données.enfant2; données.enfant5 ]
   définition f.i_ressources_ménage égal à 30 000 €
   définition f.i_date_courante égal à |2020-05-01|
   définition f.i_résidence égal à Métropole
@@ -105,7 +105,7 @@ déclaration champ d'application Test4:
   données champ d'application Données
 
 champ d'application Test4:
-  définition f.i_enfants égal à [ données.enfant1 ; données.enfant3 ]
+  définition f.i_enfants égal à [ données.enfant1; données.enfant3 ]
   définition f.i_ressources_ménage égal à 67 250 €
   définition f.i_date_courante égal à |2020-05-01|
   définition f.i_résidence égal à Métropole
@@ -131,21 +131,24 @@ déclaration champ d'application Test6:
 
 champ d'application Test6:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2009-11-10|
         -- d_rémuneration_mensuelle: 439€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ; AF.EnfantEntrée {
+      };
+      AF.EnfantEntrée {
         -- d_identifiant: 1
         -- d_date_de_naissance: |2020-09-25|
         -- d_rémuneration_mensuelle: 1949€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 78 830 €
   définition f.i_date_courante égal à |2020-05-01|
   définition f.i_résidence égal à Guadeloupe
@@ -159,7 +162,7 @@ déclaration champ d'application Test7:
 
 champ d'application Test7:
   définition f.i_enfants égal à
-    [ données.enfant1 ; données.enfant2 ; données.enfant3 ; données.enfant4 ]
+    [ données.enfant1; données.enfant2; données.enfant3; données.enfant4 ]
   définition f.i_ressources_ménage égal à 30 000 €
   définition f.i_date_courante égal à |2021-02-01|
   définition f.i_résidence égal à Métropole
@@ -172,21 +175,24 @@ déclaration champ d'application Test8:
 
 champ d'application Test8:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2004-01-01|
         -- d_rémuneration_mensuelle: 0€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ; AF.EnfantEntrée {
+      };
+      AF.EnfantEntrée {
         -- d_identifiant: 1
         -- d_date_de_naissance: |2005-01-01|
         -- d_rémuneration_mensuelle: 0€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 69945 €
   définition f.i_date_courante égal à |2021-01-01|
   définition f.i_résidence égal à Métropole
@@ -199,21 +205,24 @@ déclaration champ d'application Test9:
 
 champ d'application Test9:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2001-07-27|
         -- d_rémuneration_mensuelle: 1258€
         -- d_prise_en_charge: ServicesSociauxAllocationVerséeAuxServicesSociaux
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ; AF.EnfantEntrée {
+      };
+      AF.EnfantEntrée {
         -- d_identifiant: 1
         -- d_date_de_naissance: |2008-04-27|
         -- d_rémuneration_mensuelle: 1766€
         -- d_prise_en_charge: ServicesSociauxAllocationVerséeAuxServicesSociaux
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 75786 €
   définition f.i_date_courante égal à |2020-05-01|
   définition f.i_résidence égal à Guadeloupe
@@ -226,21 +235,24 @@ déclaration champ d'application Test10:
 
 champ d'application Test10:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2003-02-22|
         -- d_rémuneration_mensuelle: 0€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ; AF.EnfantEntrée {
+      };
+      AF.EnfantEntrée {
         -- d_identifiant: 1
         -- d_date_de_naissance: |2013-09-30|
         -- d_rémuneration_mensuelle: 300€
         -- d_prise_en_charge: GardeAlternéePartageAllocations
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 30000 €
   définition f.i_date_courante égal à |2020-04-20|
   définition f.i_résidence égal à Métropole
@@ -253,21 +265,23 @@ déclaration champ d'application Test11:
 
 champ d'application Test11:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2003-02-22|
         -- d_rémuneration_mensuelle: 0€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ; AF.EnfantEntrée {
+      };
+      AF.EnfantEntrée {
         -- d_identifiant: 1
         -- d_date_de_naissance: |2013-09-30|
         -- d_rémuneration_mensuelle: 300€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ;
+      };
       AF.EnfantEntrée {
         -- d_identifiant: 2
         -- d_date_de_naissance: |2007-04-16|
@@ -275,7 +289,8 @@ champ d'application Test11:
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 30000 €
   définition f.i_date_courante égal à |2021-12-31|
   définition f.i_résidence égal à Métropole
@@ -288,21 +303,23 @@ déclaration champ d'application Test12:
 
 champ d'application Test12:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2003-02-22|
         -- d_rémuneration_mensuelle: 0€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ; AF.EnfantEntrée {
+      };
+      AF.EnfantEntrée {
         -- d_identifiant: 1
         -- d_date_de_naissance: |2013-09-30|
         -- d_rémuneration_mensuelle: 300€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ;
+      };
       AF.EnfantEntrée {
         -- d_identifiant: 2
         -- d_date_de_naissance: |2007-04-16|
@@ -310,7 +327,7 @@ champ d'application Test12:
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ;
+      };
       AF.EnfantEntrée {
         -- d_identifiant: 3
         -- d_date_de_naissance: |2012-02-02|
@@ -318,7 +335,8 @@ champ d'application Test12:
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 20000 €
   définition f.i_date_courante égal à |2019-08-26|
   définition f.i_résidence égal à Mayotte
@@ -332,14 +350,16 @@ déclaration champ d'application Test13:
 
 champ d'application Test13:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2008-02-22|
         -- d_rémuneration_mensuelle: 0€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 65000 €
   définition f.i_date_courante égal à |2019-08-26|
   définition f.i_résidence égal à Mayotte
@@ -352,14 +372,15 @@ déclaration champ d'application Test14:
 
 champ d'application Test14:
   définition f.i_enfants égal à
-    [ AF.EnfantEntrée {
+    [
+      AF.EnfantEntrée {
         -- d_identifiant: 0
         -- d_date_de_naissance: |2004-12-22|
         -- d_rémuneration_mensuelle: 435€
         -- d_prise_en_charge: EffectiveEtPermanente
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ;
+      };
       AF.EnfantEntrée {
         -- d_identifiant: 1
         -- d_date_de_naissance: |2001-12-05|
@@ -367,7 +388,8 @@ champ d'application Test14:
         -- d_prise_en_charge: GardeAlternéeAllocataireUnique
         -- d_a_déjà_ouvert_droit_aux_allocations_familiales: vrai
         -- d_bénéficie_titre_personnel_aide_personnelle_logement: faux
-      } ]
+      }
+    ]
   définition f.i_ressources_ménage égal à 64033 €
   définition f.i_date_courante égal à |2022-05-01|
   définition f.i_résidence égal à Guadeloupe

--- a/tests/fr/tests_calculette_globale.catala_fr.result
+++ b/tests/fr/tests_calculette_globale.catala_fr.result
@@ -19,12 +19,15 @@ champ d'application Exemple1:
   définition calculette.ménage égal à
     AL.Ménage {
       -- prestations_reçues:
-        [ AL.PrestationReçue.AllocationSoutienEnfantHandicapé ;
-          AL.PrestationReçue.ComplémentFamilial ;
-          AL.PrestationReçue.AllocationsFamiliales ]
+        [
+          AL.PrestationReçue.AllocationSoutienEnfantHandicapé;
+          AL.PrestationReçue.ComplémentFamilial;
+          AL.PrestationReçue.AllocationsFamiliales
+        ]
       -- situation_familiale: Mariés contenu |2010-11-26|
       -- personnes_à_charge:
-        [ EnfantÀCharge contenu (
+        [
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- identifiant: 0
               -- nationalité: Française
@@ -35,7 +38,8 @@ champ d'application Exemple1:
               -- obligation_scolaire: Prestations_familiales.SituationObligationScolaire.Après
               -- situation_garde_alternée: GardeAlternéeCoefficientPriseEnCharge contenu 0,7
             }
-          ) ; EnfantÀCharge contenu (
+          );
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- identifiant: 1
               -- nationalité: Française
@@ -46,7 +50,8 @@ champ d'application Exemple1:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ; EnfantÀCharge contenu (
+          );
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- identifiant: 2
               -- nationalité: Française
@@ -57,7 +62,8 @@ champ d'application Exemple1:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ]
+          )
+        ]
       -- logement:
         AL.Logement {
           -- zone: Zone1
@@ -120,7 +126,8 @@ champ d'application Exemple2:
       -- prestations_reçues: []
       -- situation_familiale: Célibataire
       -- personnes_à_charge:
-        [ EnfantÀCharge contenu (
+        [
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- identifiant: 0
               -- nationalité: Française
@@ -131,7 +138,8 @@ champ d'application Exemple2:
               -- obligation_scolaire: Après
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ; EnfantÀCharge contenu (
+          );
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- identifiant: 1
               -- nationalité: Française
@@ -142,7 +150,8 @@ champ d'application Exemple2:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ]
+          )
+        ]
       -- logement:
         AL.Logement {
           -- zone: Zone2

--- a/tests/fr/tests_droit_succession.catala_fr.result
+++ b/tests/fr/tests_droit_succession.catala_fr.result
@@ -50,7 +50,7 @@ déclaration champ d'application Test3:
 champ d'application Test3:
   définition réserve_héréditaire.patrimoine_total égal à 300 000 €
   définition réserve_héréditaire.enfants égal à
-    [ enfants.base de 0 ; enfants.base de 1 ]
+    [ enfants.base de 0; enfants.base de 1 ]
   définition réserve_héréditaire.biens_usufruit_rente_viagère égal à []
   assertion réserve_héréditaire.montant_réserve_héréditaire = 100 000 €
 ```
@@ -64,7 +64,7 @@ déclaration champ d'application Test4:
 champ d'application Test4:
   définition réserve_héréditaire.patrimoine_total égal à 300 000 €
   définition réserve_héréditaire.enfants égal à
-    [ enfants.base de 0 ; enfants.base de 1 ]
+    [ enfants.base de 0; enfants.base de 1 ]
   définition réserve_héréditaire.biens_usufruit_rente_viagère égal à
     [ DS.BienUsufruitRenteViagère { -- valeur: 250 000 € -- prise_en_compte_pour_réserve_héréditaire: faux } ]
   assertion réserve_héréditaire.patrimoine_assiette_réserve_héréditaire = 50 000 €

--- a/tests/fr/tests_eligibilite_apl.catala_fr.result
+++ b/tests/fr/tests_eligibilite_apl.catala_fr.result
@@ -18,12 +18,15 @@ champ d'application Exemple1:
     AL.Ménage {
       -- résidence: Métropole
       -- prestations_reçues:
-        [ AL.PrestationReçue.AllocationSoutienEnfantHandicapé ;
-          AL.PrestationReçue.ComplémentFamilial ;
-          AL.PrestationReçue.AllocationsFamiliales ]
+        [
+          AL.PrestationReçue.AllocationSoutienEnfantHandicapé;
+          AL.PrestationReçue.ComplémentFamilial;
+          AL.PrestationReçue.AllocationsFamiliales
+        ]
       -- situation_familiale: Mariés contenu |2010-11-26|
       -- personnes_à_charge:
-        [ EnfantÀCharge contenu (
+        [
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- nationalité: Française
               -- identifiant: 0
@@ -34,7 +37,8 @@ champ d'application Exemple1:
               -- obligation_scolaire: Prestations_familiales.SituationObligationScolaire.Après
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ; EnfantÀCharge contenu (
+          );
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- nationalité: Française
               -- identifiant: 1
@@ -45,7 +49,8 @@ champ d'application Exemple1:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ; EnfantÀCharge contenu (
+          );
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- nationalité: Française
               -- identifiant: 2
@@ -56,7 +61,8 @@ champ d'application Exemple1:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ]
+          )
+        ]
       -- logement:
         AL.Logement {
           -- zone: Zone1
@@ -116,7 +122,8 @@ champ d'application Exemple2:
         [ AL.PrestationReçue.AllocationsFamiliales ]
       -- situation_familiale: Concubins
       -- personnes_à_charge:
-        [ EnfantÀCharge contenu (
+        [
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- identifiant: 0
               -- nationalité: Française
@@ -127,7 +134,8 @@ champ d'application Exemple2:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ; EnfantÀCharge contenu (
+          );
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- nationalité: Française
               -- études_apprentissage_stage_formation_pro_impossibilité_travail: faux
@@ -138,7 +146,8 @@ champ d'application Exemple2:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ]
+          )
+        ]
       -- logement:
         AL.Logement {
           -- zone: Zone2
@@ -199,7 +208,8 @@ champ d'application Exemple3:
         [ AL.PrestationReçue.AllocationsFamiliales ]
       -- situation_familiale: Concubins
       -- personnes_à_charge:
-        [ EnfantÀCharge contenu (
+        [
+          EnfantÀCharge contenu (
             AL.EnfantÀCharge {
               -- identifiant: 0
               -- nationalité: Française
@@ -210,7 +220,8 @@ champ d'application Exemple3:
               -- obligation_scolaire: Pendant
               -- situation_garde_alternée: PasDeGardeAlternée
             }
-          ) ]
+          )
+        ]
       -- logement:
         AL.Logement {
           -- zone: Zone2

--- a/tests/fr/traitements_salaires.catala_fr.result
+++ b/tests/fr/traitements_salaires.catala_fr.result
@@ -82,18 +82,18 @@ déclaration champ d'application TraitementsSalaires1:
 
 champ d'application TraitementsSalaires1:
   définition sortie égal à
-    (
-      résultat de IR.TraitementsSalairesDéclarant avec {
-        -- revenus:
-          (
-            résultat de Interface.TraitementsSalairesDéclarant avec {
-              -- traitements_salaires: 10 000 €
-            }
-          ).sortie
-        -- année_revenus: 2022
-        -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné
-      }
-    )
+  (
+    résultat de IR.TraitementsSalairesDéclarant avec {
+      -- revenus:
+        (
+          résultat de Interface.TraitementsSalairesDéclarant avec {
+            -- traitements_salaires: 10 000 €
+          }
+        ).sortie
+      -- année_revenus: 2022
+      -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné
+    }
+  )
 ```
 
 Le test ci-dessus doit donner le résultat suivant à l'exécution.
@@ -195,19 +195,19 @@ déclaration champ d'application TraitementsSalaires2:
 
 champ d'application TraitementsSalaires2:
   définition sortie égal à
-    (
-      résultat de IR.TraitementsSalairesDéclarant avec {
-        -- revenus:
-          (
-            résultat de Interface.TraitementsSalairesDéclarant avec {
-              -- frais_réels: IR.FraisRéels.Oui contenu 2000 €
-              -- traitements_salaires: 10 000 €
-            }
-          ).sortie
-        -- année_revenus: 2022
-        -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné
-      }
-    )
+  (
+    résultat de IR.TraitementsSalairesDéclarant avec {
+      -- revenus:
+        (
+          résultat de Interface.TraitementsSalairesDéclarant avec {
+            -- frais_réels: IR.FraisRéels.Oui contenu 2000 €
+            -- traitements_salaires: 10 000 €
+          }
+        ).sortie
+      -- année_revenus: 2022
+      -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné
+    }
+  )
 ```
 
 Le test ci-dessus doit donner le résultat suivant à l'exécution.
@@ -392,31 +392,31 @@ déclaration champ d'application TraitementsSalaires3:
 
 champ d'application TraitementsSalaires3:
   définition parts égal à
-    (
-      résultat de IR.NombreDeParts avec {
-        -- foyer_fiscal:
-          (
-            résultat de Interface.DescriptionFoyerFiscal avec {
-              -- veuve: vrai
-            }
-          ).sortie
-        -- année_revenus: 2022
-      }
-    )
+  (
+    résultat de IR.NombreDeParts avec {
+      -- foyer_fiscal:
+        (
+          résultat de Interface.DescriptionFoyerFiscal avec {
+            -- veuve: vrai
+          }
+        ).sortie
+      -- année_revenus: 2022
+    }
+  )
   définition traitements_salaires égal à
-    (
-      résultat de IR.TraitementsSalairesDéclarant avec {
-        -- revenus:
-          (
-            résultat de Interface.TraitementsSalairesDéclarant avec {
-              -- pensions_retraites_rentes: 20 000 €
-              -- pensions_retraites_en_capital_7_5pct: 30 000 €
-            }
-          ).sortie
-        -- année_revenus: 2022
-        -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné
-      }
-    )
+  (
+    résultat de IR.TraitementsSalairesDéclarant avec {
+      -- revenus:
+        (
+          résultat de Interface.TraitementsSalairesDéclarant avec {
+            -- pensions_retraites_rentes: 20 000 €
+            -- pensions_retraites_en_capital_7_5pct: 30 000 €
+          }
+        ).sortie
+      -- année_revenus: 2022
+      -- selecteur_plafond_abattement_pensions_retraites_rentes: Déplafonné
+    }
+  )
 ```
 
 ```catala-test-cli
@@ -515,12 +515,13 @@ Ramené au prorata pour chaque déclarant cela donne :
 ```catala
 champ d'application TraitementsSalaires4:
   # Le total des abattements doit être le plafond
-  assertion (
-    somme argent de transforme chaque résultats
-    parmi sortie.déclarations_avec_résultats_traitements_salaires en
-      résultats.abattement_pensions_retraites_rentes
-  )
-  = 4123 €
+  assertion
+    (
+      somme argent de transforme chaque résultats
+      parmi sortie.déclarations_avec_résultats_traitements_salaires en
+        résultats.abattement_pensions_retraites_rentes
+    )
+    = 4123 €
 ```
 
 ```catala-test-cli
@@ -1348,12 +1349,14 @@ déclaration champ d'application TraitementsSalaires7:
 champ d'application TraitementsSalaires7:
   définition déclarant1.traitements_salaires égal à 48 650 €
   définition déclarant1.revenus_exceptionnels_ou_différés égal à
-    [ IR.RevenuExceptionnelOuDifféré {
+    [
+      IR.RevenuExceptionnelOuDifféré {
         -- valeur: 250 000€
         -- régime: Article163_0_A
         -- échéance: RevenuDifféréÉchéanceNormale contenu 2018
         -- catégorie: TraitementsSalaires
-      } ]
+      }
+    ]
   définition déclarant2.autres_revenus_imposables_chômage_préretraite égal à
     8950 €
   définition déclarant3.pensions_retraites_rentes égal à 150 €
@@ -1661,12 +1664,14 @@ déclaration champ d'application TraitementsSalaires8:
 champ d'application TraitementsSalaires8:
   définition déclarant1.traitements_salaires égal à 72 360 €
   définition déclarant1.revenus_exceptionnels_ou_différés égal à
-    [ IR.RevenuExceptionnelOuDifféré {
+    [
+      IR.RevenuExceptionnelOuDifféré {
         -- valeur: 920 000 €
         -- régime: Article163_0_A
         -- échéance: RevenuDifféréÉchéanceNormale contenu 2017
         -- catégorie: TraitementsSalaires
-      } ]
+      }
+    ]
   définition déclarant2.traitements_salaires égal à 46 544 €
   définition déclarant2.frais_réels égal à IR.FraisRéels.Oui contenu 5 000 €
   définition déclarant3.pensions_invalidité égal à 6 936 €
@@ -1773,12 +1778,14 @@ déclaration champ d'application TraitementsSalaires9:
 champ d'application TraitementsSalaires9:
   définition déclarant1.traitements_salaires égal à 350 €
   définition déclarant1.revenus_exceptionnels_ou_différés égal à
-    [ IR.RevenuExceptionnelOuDifféré {
+    [
+      IR.RevenuExceptionnelOuDifféré {
         -- valeur: 500 000 €
         -- régime: Article163_0_A
         -- échéance: RevenuDifféréÉchéanceNormale contenu 2017
         -- catégorie: TraitementsSalaires
-      } ]
+      }
+    ]
 
   définition sortie égal à
     résultat de IR.TraitementsSalairesFoyerFiscal avec {
@@ -2759,12 +2766,14 @@ champ d'application TraitementsSalaires11:
   définition déclarant1.heures_supplémentaires_et_rtt_exonérées égal à 11 000 €
   définition déclarant1.prime_partage_valeur_exonérée égal à 6 200 €
   définition déclarant1.revenus_exceptionnels_ou_différés égal à
-    [ IR.RevenuExceptionnelOuDifféré {
+    [
+      IR.RevenuExceptionnelOuDifféré {
         -- valeur: 4 123 €
         -- régime: Article163_0_A
         -- échéance: RevenuDifféréÉchéanceNormale contenu 2018
         -- catégorie: TraitementsSalaires
-      } ]
+      }
+    ]
   définition déclarant1.gains_de_levee_doptions égal à 2 345 €
   définition déclarant2.autres_revenus_imposables_chômage_préretraite égal à
     8 000 €
@@ -2790,9 +2799,11 @@ champ d'application TraitementsSalaires11:
       -- déclarant1: déclarant1.sortie
       -- déclarant2: Déclaration contenu déclarant2.sortie
       -- déclarations_personnes_à_charge:
-        [ déclarant3.sortie ;
-          déclarant4.sortie ;
-          déclarant5.sortie ]
+        [
+          déclarant3.sortie;
+          déclarant4.sortie;
+          déclarant5.sortie
+        ]
       -- année_revenus: 2022
       -- revenus: foyer.sortie
     }

--- a/tests/fr/traitements_salaires.catala_fr.result
+++ b/tests/fr/traitements_salaires.catala_fr.result
@@ -518,8 +518,8 @@ champ d'application TraitementsSalaires4:
   assertion
     (
       somme argent de transforme chaque résultats
-      parmi sortie.déclarations_avec_résultats_traitements_salaires en
-        résultats.abattement_pensions_retraites_rentes
+        parmi sortie.déclarations_avec_résultats_traitements_salaires en
+          résultats.abattement_pensions_retraites_rentes
     )
     = 4123 €
 ```

--- a/tests/fr/tutoriel_fr.catala_fr.result
+++ b/tests/fr/tutoriel_fr.catala_fr.result
@@ -240,9 +240,10 @@ Catala permet de redéfinir précisément une variable sous une condition :
 
 ```catala
 champ d'application CalculImpôtRevenu:
-  définition pourcentage_fixe sous condition
-    personne.nombre_enfants >= 2
-  conséquence égal à 15%
+  définition pourcentage_fixe
+  sous condition personne.nombre_enfants >= 2
+  conséquence égal à
+    15%
 # Ecrire 15% est juste une abbréviation pour « 0.15 »
 ```
 
@@ -293,7 +294,9 @@ déclaration champ d'application Enfant:
 # qui représente le contenu de la variable.
 
 champ d'application Enfant:
-  règle éligible_à_article_3 sous condition âge < 18 conséquence rempli
+  règle éligible_à_article_3
+  sous condition âge < 18
+  conséquence rempli
 # Au moment de définir la valeur d’une condition à vraie, nous utilisons
 # la syntaxe spéciale « règle » au lieu de « définition ». Les règles fixent
 # les conditions à « rempli » ou à « non rempli » par des tests conditionnels.
@@ -419,9 +422,10 @@ sur le revenu prévu à l’article 1.
 champ d'application NouveauCalculImpôtRevenu:
   # Ici, nous définissons simplement une nouvelle définition conditionnelle
   # pour « l’impôt sur le revenu », qui manipule le cas particulier.
-  définition impôt_revenu sous condition
-    personne.revenu <= 10 000€
-  conséquence égal à 0€
+  définition impôt_revenu
+  sous condition personne.revenu <= 10 000€
+  conséquence égal à
+    0€
 # Quoi ? Pensez-vous que quelque chose peut-être faux avec ceci ?
 # Hmmm… Nous verrons cela plus tard !
 ```
@@ -541,9 +545,10 @@ champ d'application NouveauCalculImpôtRevenuCorrect:
 
   # Puis, vous pouvez déclarez l’exception qui se réfère à l’étiquette
   exception article_5
-  définition impôt_revenu sous condition
-    personne.revenu <= 10 000€
-  conséquence égal à 0€
+  définition impôt_revenu
+  sous condition personne.revenu <= 10 000€
+  conséquence égal à
+    0€
 ```
 
 Et le test devrait désormais fonctionner :
@@ -585,9 +590,10 @@ mentionné à l’article 1.
 ```catala
 champ d'application NouveauCalculImpôtRevenuCorrect:
   exception article_5
-  définition impôt_revenu sous condition
-    personne.nombre_enfants >= 7
-  conséquence égal à 0€
+  définition impôt_revenu
+  sous condition personne.nombre_enfants >= 7
+  conséquence égal à
+    0€
 ```
 
 Le même problème devrait être déclenché ci-dessus, pour des familles avec un
@@ -703,9 +709,10 @@ champ d'application DétermineBaseAmende:
   # Pour en revenir à notre petit problème, la solution est ici de fournir,
   # depuis l’extérieur, une définition exceptionnelle de l’impôt sur le revenu
   # pour les personnes gagnant moins de 10 000€.
-  définition calcul_impôt.impôt_revenu sous condition
-    personne.revenu <= 10 000€
-  conséquence égal à 500€
+  définition calcul_impôt.impôt_revenu
+  sous condition personne.revenu <= 10 000€
+  conséquence égal à
+    500€
 ```
 
 ## Une variable, plusieurs états
@@ -774,7 +781,9 @@ déclaration champ d'application ValeursBooléennes:
   interne valeur2 contenu booléen
 
 champ d'application ValeursBooléennes:
-  règle valeur1 sous condition faux et vrai conséquence rempli
+  règle valeur1
+  sous condition faux et vrai
+  conséquence rempli
   # Mets le booléen de la condition « valeur1 » à « vrai »,
   # si la condition « faux et vrai » est respectée.
   définition valeur2 égal à valeur1 ou bien (valeur1 et vrai) = faux
@@ -794,7 +803,10 @@ déclaration champ d'application ValeursEntières:
   interne valeur2 contenu entier
 
 champ d'application ValeursEntières:
-  définition valeur1 sous condition 12 - (5 * 3) < 65 conséquence égal à 45 * 9
+  définition valeur1
+  sous condition 12 - (5 * 3) < 65
+  conséquence égal à
+    45 * 9
   # L’opérateur « / » correspond à une division entière qui tronque vers 0.
   définition valeur2 égal à valeur1 * valeur1 * 65 * 100
 ```
@@ -812,9 +824,10 @@ déclaration champ d'application ValeursDécimales:
   interne valeur2 contenu décimal
 
 champ d'application ValeursDécimales:
-  définition valeur1 sous condition
-    12,655465446655426 - 0,45265426541654 < 12,3554654652
-  conséquence égal à 45 / 9
+  définition valeur1
+  sous condition 12,655465446655426 - 0,45265426541654 < 12,3554654652
+  conséquence égal à
+    45 / 9
   # L’opérateur « / » correspond à une division éxacte.
   # La division d’entiers produit une décimale.
   définition valeur2 égal à valeur1 * valeur1 * 65%
@@ -840,9 +853,10 @@ déclaration champ d'application ValeursMonétaires:
   interne valeur2 contenu argent
 
 champ d'application ValeursMonétaires:
-  définition valeur1 sous condition
-    12,655465446655426 - 0,45265426541654 < 12,3554654652
-  conséquence égal à (décimal de 45) / (décimal de 9)
+  définition valeur1
+  sous condition 12,655465446655426 - 0,45265426541654 < 12,3554654652
+  conséquence égal à
+    (décimal de 45) / (décimal de 9)
   définition valeur2 égal à
     1,00€ * (((6 520,23€ - 320,45€) * valeur1) / 45€)
 ```
@@ -887,7 +901,7 @@ déclaration champ d'application ValeursDeListe:
   interne valeur2 contenu entier
 
 champ d'application ValeursDeListe:
-  définition valeur1 égal à [ 45 ; -6 ; 3 ; 4 ; 0 ; 2155 ]
+  définition valeur1 égal à [ 45; -6; 3; 4; 0; 2155 ]
   définition valeur2 égal à
     # somme de carré
     somme entier de transforme chaque i parmi valeur1 en (i * i)
@@ -1068,7 +1082,8 @@ champ d'application InclureDansRevenuBrut:
 ```catala
 déclaration excédent
   contenu argent
-  dépend de x contenu argent,
+  dépend de
+    x contenu argent,
     y contenu argent
   égal à
     si x > y alors x - y

--- a/tests/fr/vérifications.catala_fr.result
+++ b/tests/fr/vérifications.catala_fr.result
@@ -24,11 +24,14 @@ champ d'application NombreDeParts:
   assertion (
     1
     = nombre de
-      liste de case parmi [ foyer_fiscal.mariées ;
-        foyer_fiscal.célibataire ;
-        foyer_fiscal.pacsées ;
-        foyer_fiscal.divorcée_séparées ;
-        foyer_fiscal.veuve ]
+      liste de case
+      parmi [
+        foyer_fiscal.mariées;
+        foyer_fiscal.célibataire;
+        foyer_fiscal.pacsées;
+        foyer_fiscal.divorcée_séparées;
+        foyer_fiscal.veuve
+      ]
         tel que case = vrai
   )
 ```
@@ -48,13 +51,14 @@ champ d'application NombreDeParts:
   # demi-part supplémentaire ne peut être accordée au couple marié, dans lequel
   # l’épouse a cessé de percevoir la pension qui est à l'origine de cet
   # avantage." (Rép. Boucheron : AN 30 avril 1990 p. 2111 n°24112).
-  assertion non (
-    foyer_fiscal.pensionné_veuve_de_guerre
-    et selon situation_familiale sous forme
-    -- Mariées : vrai
-    -- Pacsées : vrai
-    -- n'importe quel : faux
-  )
+  assertion
+    non (
+      foyer_fiscal.pensionné_veuve_de_guerre
+      et selon situation_familiale sous forme
+        -- Mariées : vrai
+        -- Pacsées : vrai
+        -- n'importe quel : faux
+    )
 # TODO juridique : faut-il exiger que la case "veuve" soit cochée et interdire
 # la case "célibataire" si AG est cochée?
 
@@ -91,14 +95,16 @@ champ d'application NombreDeParts:
   )
   # La case AL n'est pas compatible avec la case BT ni avec la case DN.
   # Voir 195 1° du CGI, https://gitlab.adullact.net/dgfip/ir-catala/-/issues/2.
-  assertion non (
-    foyer_fiscal.célibataire_divorcé_veuf_sans_enfant
-    et foyer_fiscal.parent_isolé
-  )
-  assertion non (
-    foyer_fiscal.célibataire_divorcé_veuf_sans_enfant
-    et foyer_fiscal.nombre_enfants_majeurs_mariés_ou_chargés_famille != 0,0
-  )
+  assertion
+    non (
+      foyer_fiscal.célibataire_divorcé_veuf_sans_enfant
+      et foyer_fiscal.parent_isolé
+    )
+  assertion
+    non (
+      foyer_fiscal.célibataire_divorcé_veuf_sans_enfant
+      et foyer_fiscal.nombre_enfants_majeurs_mariés_ou_chargés_famille != 0,0
+    )
 ```
 ### Case AW
 
@@ -190,26 +196,28 @@ pas relever du régime de l'article 163-0 A bis.
 
 ```catala
 champ d'application TraitementsSalairesDéclarant:
-  assertion pour tout revenu_exceptionnel_ou_différé
-  parmi revenus.revenus_exceptionnels_ou_différés
-    on a selon revenu_exceptionnel_ou_différé.catégorie sous forme
-    -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes : vrai
-    -- TraitementsSalaires : vrai
-    -- n'importe quel : faux
+  assertion
+    pour tout revenu_exceptionnel_ou_différé
+    parmi revenus.revenus_exceptionnels_ou_différés
+      on a selon revenu_exceptionnel_ou_différé.catégorie sous forme
+      -- CatégorieRevenuExceptionnelOuDifféré.PensionsRetraitesRentes : vrai
+      -- TraitementsSalaires : vrai
+      -- n'importe quel : faux
 
 champ d'application TraitementsSalairesFoyerFiscal:
-  assertion pour tout revenu_exceptionnel_ou_différé
-  parmi revenus.revenus_exceptionnels_ou_différés
-    on a (
-      selon revenu_exceptionnel_ou_différé.catégorie sous forme
-      -- RenteViagèreOnéreux : vrai
-      -- n'importe quel : faux
-    )
-    et (
-      selon revenu_exceptionnel_ou_différé.régime sous forme
-      -- Article163_0_A : vrai
-      -- Article163_0_A_bis : faux
-    )
+  assertion
+    pour tout revenu_exceptionnel_ou_différé
+    parmi revenus.revenus_exceptionnels_ou_différés
+      on a (
+        selon revenu_exceptionnel_ou_différé.catégorie sous forme
+        -- RenteViagèreOnéreux : vrai
+        -- n'importe quel : faux
+      )
+      et (
+        selon revenu_exceptionnel_ou_différé.régime sous forme
+        -- Article163_0_A : vrai
+        -- Article163_0_A_bis : faux
+      )
 ```
 
 ## Revenus quotientés


### PR DESCRIPTION
Main changes:
- multi-line expressions always start on their own line (within other nodes)
- some verbose constructs like `under condition` always start a line
- binary operators indent their rhs when appropriate (e.g in `1 + 2 * 3` the `*` would be indented)