### PR TITLE
Support topiary 0.6.x and fix Windows path handling

### DIFF
--- a/catala-format.opam
+++ b/catala-format.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "3.13"}
   "cmdliner" {>= "2.0.0"}
   "lwt" {with-test}
-  "topiary" {>= "0.5.1" & < "0.6"}
+  "topiary" {>= "0.6.0" & < "0.7"}
   "conf-c++"
   "re" {>= "1.11"}
 ]

--- a/catala.ncl
+++ b/catala.ncl
@@ -4,27 +4,39 @@
     catala_en = {
       extensions = ["catala_en", "catala_en.md"],
       grammar = {
-        git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "6c70cabc",
-        subdir = "catala_en",
+        source = {
+          git = {
+            git = "https://github.com/CatalaLang/tree-sitter-catala.git",
+            rev = "6c70cabc86f293d6eb3209275efc1d080a97d7cc",
+            subdir = "catala_en",
+          }
+        }
       }
     },
 
     catala_fr = {
       extensions = ["catala_fr", "catala_fr.md"],
       grammar = {
-        git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "6c70cabc",
-        subdir = "catala_fr",
+        source = {
+          git = {
+            git = "https://github.com/CatalaLang/tree-sitter-catala.git",
+            rev = "6c70cabc86f293d6eb3209275efc1d080a97d7cc",
+            subdir = "catala_fr",
+          }
+        }
       }
     },
 
     catala_pl = {
       extensions = ["catala_pl", "catala_pl.md"],
       grammar = {
-        git = "https://github.com/CatalaLang/tree-sitter-catala.git",
-        rev = "6c70cabc",
-        subdir = "catala_pl",
+        source = {
+          git = {
+            git = "https://github.com/CatalaLang/tree-sitter-catala.git",
+            rev = "6c70cabc86f293d6eb3209275efc1d080a97d7cc",
+            subdir = "catala_pl",
+          }
+        }
       }
     }
 

--- a/src/main.ml
+++ b/src/main.ml
@@ -49,6 +49,12 @@ let process_out cmd args =
 
 let ( / ) = Filename.concat
 
+(* On Windows, topiary passes file paths to nickel-lang-core which embeds them
+   in `import "..."` string literals. Backslashes are not valid Nickel escape
+   sequences, so we convert them to forward slashes (accepted by Windows APIs). *)
+let normalize_path s =
+  if Sys.win32 then String.map (function '\\' -> '/' | c -> c) s else s
+
 let check_and_build ?config_file ~query_file ~topiary_path () =
   let topiary_path =
     if Sys.file_exists topiary_path then topiary_path else topiary_path ^ ".exe"
@@ -57,7 +63,13 @@ let check_and_build ?config_file ~query_file ~topiary_path () =
     ([query_file; topiary_path]
     @ match config_file with None -> [] | Some x -> [x])
   |> function
-  | true -> Some { query_file; config_file; topiary_path }
+  | true ->
+    Some
+      {
+        query_file = normalize_path query_file;
+        config_file = Option.map normalize_path config_file;
+        topiary_path;
+      }
   | false -> None
 
 let lookup_windows () =

--- a/src/main.ml
+++ b/src/main.ml
@@ -72,27 +72,6 @@ let check_and_build ?config_file ~query_file ~topiary_path () =
       }
   | false -> None
 
-let lookup_windows () =
-  try
-    let ( let*? ) b f = if not b then None else f () in
-    let*? () = Sys.win32 in
-    let*? () = Sys.getenv_opt "LOCALAPPDATA" <> None in
-    let appdata_dir = Sys.getenv "LOCALAPPDATA" in
-    let catala_install_dir = appdata_dir / "Catala" in
-    let query_file = catala_install_dir / "catala.scm" in
-    let config_file =
-      None
-      (* ignore config file on windows installation, we use the built-in value
-         set in the topiary's fork *)
-    in
-    let topiary_path = catala_install_dir / "topiary" in
-    match check_and_build ~query_file ?config_file ~topiary_path () with
-    | None -> None
-    | Some config ->
-      Unix.putenv "TOPIARY_CACHE" catala_install_dir;
-      Some config
-  with _ -> None
-
 let exec_dir =
   lazy
     (let cmd = Sys.argv.(0) in
@@ -149,7 +128,6 @@ let lookup_exec_dir () =
 
 let files_lookup () =
   let ( let* ) x f = match x with Some x -> x | None -> f () in
-  let* () = lookup_windows () in
   let* () = lookup_opam_optimist () in
   let* () = lookup_exec_dir () in
   let* () = lookup_opam_slow () in


### PR DESCRIPTION
Bump topiary to `>= 0.6.0, < 0.7` and fix Windows path handling.

- topiary 0.6 changed its Nickel config schema (grammar sources now use the
  nested `source = { git = … }` form, tweag/topiary#830/#811); `catala.ncl` is
  migrated accordingly and is not backward-compatible with 0.5.
- 0.6 is the first topiary release with Windows CI and fixes the Windows
  file-persistence bug (tweag/topiary#812/#813). On top of that, `main.ml`
  normalizes backslashes to forward slashes in paths passed to topiary, since
  topiary embeds them in Nickel `import "…"` literals where `\` isn't a valid
  escape.

Upper bound capped at `< 0.7`; schema only verified against 0.6.x.